### PR TITLE
docs: Add README and update CLAUDE.md conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,3 +76,7 @@ packages/
 1. APIがローカルの `~/.claude/plans/*.md` ファイルを直接読み書き
 2. 削除時はデフォルトで `archive/` サブディレクトリへ移動（ソフトデリート）
 3. タイトルはMarkdownの最初のH1から抽出、セクションはH2から抽出
+
+## Conventions
+
+- **Language**: Write all code comments, commit messages, and PR descriptions in English

--- a/README.md
+++ b/README.md
@@ -1,0 +1,94 @@
+# Claude Plans Manager (ccplans)
+
+A web-based tool for managing Claude Code plan files stored in `~/.claude/plans/`.
+
+## Features
+
+- Browse and search plan files with full-text search
+- View plans with Markdown rendering
+- Create, edit, rename, and delete plans
+- Open plans in external apps (VS Code, Terminal)
+- Soft delete with archive support
+
+## Prerequisites
+
+- Node.js 20+
+- pnpm 9+
+
+## Getting Started
+
+```bash
+# Clone the repository
+git clone https://github.com/tanabe1478/ccplans.git
+cd ccplans
+
+# Install dependencies
+pnpm install
+
+# Start development servers (API + Web)
+pnpm dev
+```
+
+The web app will be available at http://localhost:5173 and the API at http://localhost:3001.
+
+## Project Structure
+
+```
+apps/
+  api/          # Fastify REST API server
+  web/          # React SPA (Vite + Tailwind)
+packages/
+  shared/       # Shared TypeScript types
+```
+
+## Available Scripts
+
+| Command | Description |
+|---------|-------------|
+| `pnpm dev` | Start all dev servers |
+| `pnpm build` | Build all packages |
+| `pnpm test` | Run all tests |
+| `pnpm lint` | Type check all packages |
+| `pnpm format` | Format code with Prettier |
+
+### Package-specific commands
+
+```bash
+# Run tests for a specific package
+pnpm --filter @ccplans/api test
+
+# Watch mode for tests
+pnpm --filter @ccplans/api test:watch
+
+# Run a single test file
+pnpm --filter @ccplans/api test -- planService.test.ts
+```
+
+## Configuration
+
+Environment variables (optional):
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PORT` | `3001` | API server port |
+| `HOST` | `0.0.0.0` | API server host |
+| `PLANS_DIR` | `~/.claude/plans` | Directory containing plan files |
+| `CORS_ORIGINS` | `http://localhost:5173` | Allowed CORS origins (comma-separated) |
+
+## API Endpoints
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/plans` | List all plans |
+| GET | `/api/plans/:filename` | Get plan details |
+| POST | `/api/plans` | Create a new plan |
+| PUT | `/api/plans/:filename` | Update a plan |
+| DELETE | `/api/plans/:filename` | Delete a plan (archive) |
+| POST | `/api/plans/:filename/rename` | Rename a plan |
+| POST | `/api/plans/:filename/open` | Open in external app |
+| GET | `/api/search?q=query` | Search plans |
+| GET | `/api/health` | Health check |
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary
- Add comprehensive README with project overview, setup instructions, and API documentation
- Add convention to CLAUDE.md requiring English for code comments, commit messages, and PR descriptions

## Changes
- `README.md`: New file with getting started guide, project structure, available scripts, environment variables, and API endpoints
- `CLAUDE.md`: Added Conventions section specifying English language requirement

## Test plan
- [x] README renders correctly on GitHub
- [x] All documented commands work as expected

🤖 Generated with [Claude Code](https://claude.ai/claude-code)