### PR TITLE
fix: Improve dark mode visibility for filter inputs and dropdowns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ playwright/.cache/
 
 # Claude Code local settings
 .claude/
+.mcp.json
 
 # Python
 __pycache__/

--- a/apps/web/src/components/plan/PlanActions.tsx
+++ b/apps/web/src/components/plan/PlanActions.tsx
@@ -235,7 +235,7 @@ export function PlanActions({ filename, onDeleted }: PlanActionsProps) {
             type="text"
             value={newFilename}
             onChange={(e) => setNewFilename(e.target.value)}
-            className="w-full rounded-md border px-3 py-2 text-sm"
+            className="w-full rounded-md border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground"
             placeholder="new-filename.md"
           />
         </div>

--- a/apps/web/src/pages/HomePage.tsx
+++ b/apps/web/src/pages/HomePage.tsx
@@ -100,7 +100,7 @@ export function HomePage() {
             placeholder="フィルター..."
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className="w-full rounded-md border px-3 py-2 text-sm"
+            className="w-full rounded-md border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground"
           />
         </div>
 
@@ -109,7 +109,7 @@ export function HomePage() {
           <select
             value={sortBy}
             onChange={(e) => setSortBy(e.target.value as 'name' | 'date' | 'size')}
-            className="rounded-md border px-2 py-2 text-sm"
+            className="rounded-md border bg-background px-2 py-2 text-sm text-foreground"
           >
             <option value="date">Date</option>
             <option value="name">Name</option>
@@ -129,7 +129,7 @@ export function HomePage() {
         <select
           value={statusFilter}
           onChange={(e) => setStatusFilter(e.target.value as PlanStatus | 'all')}
-          className="rounded-md border px-2 py-2 text-sm"
+          className="rounded-md border bg-background px-2 py-2 text-sm text-foreground"
         >
           <option value="all">All Status</option>
           <option value="todo">ToDo</option>
@@ -142,7 +142,7 @@ export function HomePage() {
           <select
             value={projectFilter}
             onChange={(e) => setProjectFilter(e.target.value)}
-            className="rounded-md border px-2 py-2 text-sm max-w-[200px]"
+            className="rounded-md border bg-background px-2 py-2 text-sm text-foreground max-w-[200px]"
           >
             <option value="all">All Projects</option>
             {uniqueProjects.map((project) => (


### PR DESCRIPTION
## Summary
- Add `bg-background`, `text-foreground`, `placeholder:text-muted-foreground` to search input and select elements in HomePage
- Apply same fix to rename input in PlanActions
- Add `.mcp.json` to gitignore

## Before
Placeholder text and dropdown values were invisible in dark mode (white text on white background).

## After
All filter elements are now visible in both light and dark modes.

## Test Plan
- [x] Manual verification with Playwright MCP screenshot
- Dark mode filter inputs now show placeholder text
- Dark mode dropdowns now show selected values

🤖 Generated with [Claude Code](https://claude.com/claude-code)