### PR TITLE
docs: Add architecture codemaps

### DIFF
--- a/.reports/codemap-diff.txt
+++ b/.reports/codemap-diff.txt
@@ -1,0 +1,19 @@
+Codemap Update Report
+=====================
+Date: 2026-02-11T01:15:00Z
+Commit: 10183ca (main)
+Previous: N/A (initial creation)
+
+Files Created:
+  codemaps/architecture.md  - Overall architecture, stack, data flow
+  codemaps/backend.md       - 10 routes, 17 services, status transitions
+  codemaps/frontend.md      - 10 pages, component tree, hooks, stores
+  codemaps/data.md          - Types, schemas, file storage layout
+
+Diff: N/A (first generation)
+
+Key additions since last codemap:
+  - Review mode (ReviewViewer, InlineComment, CommentForm, useReviewComments)
+  - SectionNav component for plan detail
+  - Line numbers in PlanViewer
+  - GitHub-style diff CSS (.review-file, .review-diff-*)

--- a/codemaps/architecture.md
+++ b/codemaps/architecture.md
@@ -1,0 +1,54 @@
+# Architecture Codemap
+
+> Freshness: 2026-02-11T01:15:00Z | Commit: 10183ca
+
+## Package Structure
+
+```
+ccplans/                          pnpm monorepo
+├── apps/api/                     Fastify REST API (port 3001)
+│   └── depends: @ccplans/shared
+├── apps/web/                     React SPA + Vite (port 5173)
+│   └── depends: @ccplans/shared
+├── packages/shared/              Shared TypeScript types (types only)
+└── e2e/                          Playwright E2E tests
+```
+
+## Data Flow
+
+```
+~/.claude/plans/*.md  ←→  apps/api (Fastify)  ←→  apps/web (React)
+        ↕                       ↕                       ↕
+   .history/              auditService            localStorage
+   .audit.jsonl           validationSvc           (review comments)
+   archive/               conflictSvc             Zustand stores
+   .saved-views.json                              TanStack Query
+```
+
+## Stack
+
+| Layer      | Technology                                       |
+|------------|--------------------------------------------------|
+| Frontend   | React 18, Vite, Tailwind CSS, Zustand, TanStack Query |
+| Backend    | Fastify, tsx, Node.js                            |
+| Types      | TypeScript (strict), shared via workspace        |
+| Testing    | Vitest (unit), Playwright (E2E)                  |
+| Build      | pnpm workspaces, tsc, Vite                       |
+
+## Key Commands
+
+```bash
+pnpm dev            # API + Web concurrent dev
+pnpm build          # All packages
+pnpm test           # All unit tests
+pnpm test:e2e       # Playwright E2E
+```
+
+## File Storage
+
+- Plans: `~/.claude/plans/*.md` (Markdown with YAML frontmatter)
+- History: `~/.claude/plans/.history/{filename}/{timestamp}.md`
+- Archive: `~/.claude/plans/archive/`
+- Audit: `~/.claude/plans/.audit.jsonl`
+- Views: `~/.claude/plans/.saved-views.json`
+- Review comments: `localStorage` (per-plan key)

--- a/codemaps/backend.md
+++ b/codemaps/backend.md
@@ -1,0 +1,67 @@
+# Backend Codemap (apps/api)
+
+> Freshness: 2026-02-11T01:15:00Z | Commit: 10183ca
+
+## Entry Point
+
+`src/index.ts` → Fastify server, CORS, route registration, health check
+
+## Configuration
+
+`src/config.ts` → plansDir, archiveDir, port, CORS origins, retention
+
+## Routes (10 modules)
+
+| Module               | Prefix              | Key Endpoints                                    |
+|----------------------|---------------------|--------------------------------------------------|
+| `routes/plans.ts`    | `/api/plans`        | GET list, GET :filename, POST, PUT, DELETE, PATCH status, subtasks, history, rollback |
+| `routes/search.ts`   | `/api/search`       | GET ?q=...                                       |
+| `routes/views.ts`    | `/api/views`        | GET list, POST, PUT :id, DELETE :id              |
+| `routes/notifications.ts` | `/api/notifications` | GET, POST mark-read                        |
+| `routes/archive.ts`  | `/api/archive`      | GET list, POST restore, DELETE permanent         |
+| `routes/dependencies.ts` | `/api/dependencies` | GET graph                                   |
+| `routes/templates.ts`| `/api/templates`    | CRUD + POST create-from-template                 |
+| `routes/export.ts`   | `/api/export`       | POST bulk (JSON/CSV/ZIP)                         |
+| `routes/import.ts`   | `/api/import`       | POST bulk markdown                               |
+| `routes/admin.ts`    | `/api/admin`        | POST migrate, GET audit, POST cleanup            |
+
+## Services (17 modules)
+
+**Core**:
+- `planService.ts` → CRUD, frontmatter parse/update, file I/O
+- `searchService.ts` → Full-text search across plans
+- `queryParser.ts` → Advanced query syntax (status:, tag:, project:, assignee:)
+
+**Quality & Ops**:
+- `auditService.ts` → Operation audit log (`.audit.jsonl`)
+- `validationService.ts` → Schema validation, consistency checks
+- `conflictService.ts` → External modification detection
+- `migrationService.ts` → Frontmatter schema migration
+
+**History**:
+- `historyService.ts` → Version snapshots (`.history/`), diff, rollback
+- `archiveService.ts` → Soft delete, restore, TTL
+
+**Domain**:
+- `dependencyService.ts` → Dependency graph, cycle detection, critical path
+- `subtaskService.ts` → Subtask CRUD in frontmatter
+- `statusTransitionService.ts` → Valid transition enforcement
+- `notificationService.ts` → Due date/blocking alerts
+- `viewService.ts` → Saved view persistence
+- `templateService.ts` → Template management
+
+**Utilities**:
+- `nameGenerator.ts` → `adjective-verb-noun.md` filename
+- `openerService.ts` → Open in VSCode/Terminal
+- `exportService.ts` / `importService.ts` → Bulk operations
+
+## Status Transitions
+
+```
+todo → in_progress → review → completed
+  ↑         ↑          │         │
+  └─────────┼──────────┘         │
+            └────────────────────┘
+```
+
+Invalid: `todo → completed`, `in_progress → completed` (must go through review)

--- a/codemaps/data.md
+++ b/codemaps/data.md
@@ -1,0 +1,95 @@
+# Data Models Codemap
+
+> Freshness: 2026-02-11T01:15:00Z | Commit: 10183ca
+
+## Source: `packages/shared/src/types/`
+
+### Plan Types (`plan.ts`)
+
+```
+PlanStatus    = 'todo' | 'in_progress' | 'review' | 'completed'
+PlanPriority  = 'low' | 'medium' | 'high' | 'critical'
+
+PlanFrontmatter {
+  created?, modified?         # ISO timestamps
+  projectPath?, sessionId?    # Claude session context
+  status?: PlanStatus
+  priority?: PlanPriority
+  dueDate?: string            # ISO date
+  tags?: string[]
+  estimate?: string
+  blockedBy?: string[]        # Dependency filenames
+  assignee?: string
+  archivedAt?: string
+  subtasks?: Subtask[]
+  schemaVersion?: number
+}
+
+Subtask {
+  id, title, status: 'todo'|'done'
+  assignee?, dueDate?
+}
+
+PlanMeta {
+  filename, title             # title from first H1
+  createdAt, modifiedAt, size
+  preview                     # first ~200 chars
+  sections: string[]          # H2 headings
+  relatedProject?
+  frontmatter?: PlanFrontmatter
+}
+
+PlanDetail extends PlanMeta {
+  content: string             # Full markdown
+}
+```
+
+### API Types (`api.ts`)
+
+**Requests**: CreatePlanRequest, UpdatePlanRequest, UpdateStatusRequest, BulkDeleteRequest, BulkStatusRequest, BulkTagsRequest, BulkPriorityRequest, BulkAssigneeRequest, SubtaskActionRequest (discriminated union: add|update|delete|toggle), SearchQuery
+
+**Responses**: BulkOperationResponse (succeeded/failed arrays), SuccessResponse, ApiError
+
+### Additional Domain Models
+
+```
+PlanVersion    { filename, timestamp, content }
+DiffResult     { lines: Array<{type: added|removed|unchanged, content}> }
+ArchivedPlan   { filename, archivedAt, expiresAt?, meta }
+Notification   { id, type, severity, message, planFilename, read }
+SavedView      { id, name, filters, sort, isPreset }
+PlanTemplate   { id, name, category, description, content, defaultFrontmatter }
+DependencyGraph { nodes, edges, cycles, criticalPath }
+AuditEntry     { timestamp, operation, filename, details }
+SearchResult   { filename, matches: Array<{line, text, highlight}> }
+```
+
+### Review Types (`apps/web/src/lib/types/review.ts`)
+
+```
+ReviewComment {
+  id: string (uuid)
+  line: number | [number, number]   # single line or range
+  body: string
+  createdAt, updatedAt: string
+}
+
+ReviewCommentsStorage {
+  version: 1
+  comments: ReviewComment[]
+}
+```
+
+Storage: `localStorage` key `ccplans-review-comments-{filename}`
+
+## File-Based Storage
+
+| Data              | Location                              | Format        |
+|-------------------|---------------------------------------|---------------|
+| Plans             | `~/.claude/plans/*.md`                | Markdown+YAML |
+| History           | `~/.claude/plans/.history/{file}/{ts}.md` | Markdown  |
+| Archive           | `~/.claude/plans/archive/*.md`        | Markdown+YAML |
+| Audit log         | `~/.claude/plans/.audit.jsonl`        | JSONL         |
+| Saved views       | `~/.claude/plans/.saved-views.json`   | JSON          |
+| Notifications     | `~/.claude/plans/.notifications-read.json` | JSON     |
+| Review comments   | Browser localStorage                  | JSON          |

--- a/codemaps/frontend.md
+++ b/codemaps/frontend.md
@@ -1,0 +1,93 @@
+# Frontend Codemap (apps/web)
+
+> Freshness: 2026-02-11T01:15:00Z | Commit: 10183ca
+
+## Entry
+
+`main.tsx` → React root (QueryClient, BrowserRouter) → `App.tsx` (routes, theme)
+
+## Pages (10)
+
+| Route                       | Component         | Purpose                          |
+|-----------------------------|-------------------|----------------------------------|
+| `/`                         | `HomePage`        | Plan list, filters, bulk actions |
+| `/plan/:filename`           | `ViewPage`        | Detail with tabs + section nav   |
+| `/plan/:filename/review`    | `ReviewPage`      | Inline commenting (diff-style)   |
+| `/search`                   | `SearchPage`      | Search results                   |
+| `/kanban`                   | `KanbanPage`      | Kanban board by status           |
+| `/calendar`                 | `CalendarPage`    | Calendar view by due date        |
+| `/archive`                  | `ArchivePage`     | Archived plans                   |
+| `/dependencies`             | `DependencyPage`  | Dependency graph                 |
+| `/templates`                | `TemplatesPage`   | Template library                 |
+| `/backups`                  | `BackupPage`      | Backup/restore                   |
+
+## State Management (Zustand)
+
+**`stores/planStore.ts`**: Selection, view mode, sort, filters, saved views
+**`stores/uiStore.ts`**: Theme, sidebar, modal, toasts
+
+## Data Fetching (TanStack Query)
+
+| Hook                    | Purpose                              |
+|-------------------------|--------------------------------------|
+| `usePlans.ts`           | Plan CRUD, status, subtask, bulk ops |
+| `useSearch.ts`          | Search query                         |
+| `useViews.ts`           | Saved views CRUD                     |
+| `useNotifications.ts`   | Notifications + mark read            |
+| `useHistory.ts`         | Version history, diff, rollback      |
+| `useArchive.ts`         | Archive operations                   |
+| `useDependencies.ts`    | Dependency graph                     |
+| `useTemplates.ts`       | Template CRUD                        |
+| `useImportExport.ts`    | Import/export/backup                 |
+| `useReviewComments.ts`  | Review comments (localStorage)       |
+
+## Component Tree
+
+```
+layout/
+├── Layout.tsx              App shell
+└── Header.tsx              Logo, theme, notifications
+
+components/plan/
+├── PlanList.tsx             Card grid + checkboxes
+├── PlanCard.tsx             Individual card
+├── PlanViewer.tsx           Markdown rendering (ReactMarkdown + rehype)
+├── PlanActions.tsx          Dropdown menu
+├── StatusBadge.tsx          Colored badge
+├── StatusDropdown.tsx       Transition dropdown
+├── ProjectBadge.tsx         Project path
+├── DependencyBadge.tsx      Dependency indicator
+├── SubtaskList.tsx          Subtask checklist
+├── HistoryPanel.tsx         Version diff viewer
+├── BulkActionBar.tsx        Bulk operations bar
+├── DeleteConfirmDialog.tsx  Deletion modal
+└── SectionNav.tsx           Section sidebar (h2 anchors)
+
+components/review/
+├── ReviewViewer.tsx         Plain text table (line-by-line diff)
+├── ReviewToolbar.tsx        Count, Copy All, Clear All
+├── InlineComment.tsx        Comment card (edit/delete/copy)
+└── CommentForm.tsx          New/edit form with quoted context
+
+components/search/           SearchBar
+components/notifications/    NotificationBell, NotificationPanel
+components/templates/        TemplateSelectDialog
+components/views/            SavedViewsSidebar
+components/export/           ExportDialog
+components/import/           ImportDialog
+components/ui/               Button, Dialog, Toasts
+```
+
+## API Client
+
+`lib/api/client.ts` → `fetchApi<T>()` wrapper + `api.*` namespace (plans, search, views, notifications, archive, dependencies, templates, export, import, backup)
+
+## CSS
+
+`globals.css`:
+- Tailwind base + CSS variables (light/dark)
+- `.markdown-content` → rendered Markdown styles
+- `.with-line-numbers` → line-numbered Markdown
+- `.review-file` / `.review-diff-*` → GitHub-style diff table
+- `.section-nav` → section navigation sidebar
+- `.dark .hljs-*` → dark mode syntax highlighting


### PR DESCRIPTION
## Summary

- Add `codemaps/` directory with token-lean architecture documentation
- Update `CLAUDE.md` to reference codemaps for detailed architecture info

## Files

| File | Content |
|------|---------|
| `codemaps/architecture.md` | Overall structure, package dependencies, data flow, stack |
| `codemaps/backend.md` | 10 API routes, 17 services, status transition diagram |
| `codemaps/frontend.md` | 10 pages, component tree, hooks, stores, CSS architecture |
| `codemaps/data.md` | Type definitions, schemas, file storage layout |
| `.reports/codemap-diff.txt` | Update tracking report |
| `CLAUDE.md` | Updated to reference codemaps, reflect current feature set |

## Test plan

- [x] Documentation only - no code changes
- [x] CLAUDE.md accurately reflects current architecture

🤖 Generated with [Claude Code](https://claude.com/claude-code)