### PR TITLE
feat: Add worktree-setup skill and fix Playwright server reuse

### DIFF
--- a/.claude/skills/worktree-setup/SKILL.md
+++ b/.claude/skills/worktree-setup/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: worktree-setup
+description: Setup guide for developing in a git worktree of the ccplans monorepo. Covers dependency installation, build verification, and per-worktree configuration differences. Use when starting work in a new worktree.
+disable-model-invocation: false
+---
+
+# Worktree Setup for ccplans
+
+Guide for environment setup when working in a git worktree of this pnpm monorepo.
+
+## Environment Setup
+
+After creating a worktree (e.g. via `/worktree` skill), run these steps:
+
+```bash
+# 1. Install dependencies (node_modules is NOT shared between worktrees)
+pnpm install
+
+# 2. Build all packages
+pnpm build
+
+# 3. Run unit tests to verify
+pnpm --filter @ccplans/api test
+pnpm --filter @ccplans/web test
+```
+
+The lockfile (`pnpm-lock.yaml`) is git-tracked and shared, so install reuses the
+pnpm cache and completes quickly.
+
+## What Is Shared Between Worktrees
+
+| Shared (git-tracked) | NOT shared (.gitignore) |
+|---|---|
+| Source code, pnpm-lock.yaml | `node_modules/`, `dist/` |
+| CLAUDE.md, configs, test fixtures | `.env`, `.claude/settings.local.json` |
+
+**Important:** `.claude/settings.local.json` (tool permissions) is per-worktree.
+Permissions approved in the main repo do NOT carry over to new worktrees.
+Each worktree starts with a fresh permission set.
+
+## Syncing with Main
+
+When the worktree branch is behind main:
+
+```bash
+git fetch origin
+git merge origin/main
+```
+
+After merging, re-run `pnpm install` if `pnpm-lock.yaml` changed.

--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,8 @@ playwright/.cache/
 .playwright-mcp/
 
 # Claude Code local settings
-.claude/
+.claude/*
+!.claude/skills/
 .mcp.json
 
 # Python

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,10 @@ hooks/     - Claude Code用hookスクリプト
 4. YAMLフロントマターからメタデータ（status, projectPath等）を解析
 5. PostToolUseフック（`hooks/plan-metadata/inject.py`）でプラン作成時にfrontmatterを自動挿入
 
+## Worktree Development
+
+This repo supports `git worktree`. See skill `worktree-setup` for setup instructions.
+
 ## Conventions
 
 - **Language**: Write all code comments, commit messages, and PR descriptions in English

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -28,7 +28,7 @@ export default defineConfig({
       command: 'pnpm --filter @ccplans/api dev',
       cwd: '..',
       url: 'http://localhost:3001/api/health',
-      reuseExistingServer: !process.env.CI,
+      reuseExistingServer: false,
       timeout: 120 * 1000,
       env: {
         PLANS_DIR: fixturesDir,
@@ -38,7 +38,7 @@ export default defineConfig({
       command: 'pnpm --filter @ccplans/web dev',
       cwd: '..',
       url: 'http://localhost:5173',
-      reuseExistingServer: !process.env.CI,
+      reuseExistingServer: false,
       timeout: 120 * 1000,
     },
   ],


### PR DESCRIPTION
## Summary

- Add `.claude/skills/worktree-setup/SKILL.md` — a Claude Code skill documenting how to set up a worktree for this pnpm monorepo (dependency install, build, shared vs non-shared files)
- Fix `reuseExistingServer: false` in `e2e/playwright.config.ts` to prevent E2E tests from accidentally reusing another worktree's or the main repo's dev server
- Update `.gitignore` to track `.claude/skills/` while keeping other `.claude/` contents (e.g. `settings.local.json`) ignored
- Add worktree skill reference to `CLAUDE.md`

## Context

When developing with `git worktree`, Playwright's `reuseExistingServer: !process.env.CI` caused E2E tests to reuse the main repo's running dev server, leading to selector mismatches between branches. Setting it to `false` ensures each test run starts its own server from the correct codebase.

## Test plan

- [ ] `pnpm build` passes
- [ ] `pnpm --filter @ccplans/api test` passes
- [ ] `pnpm --filter @ccplans/web test` passes
- [ ] `pnpm test:e2e` passes (starts its own server even if another dev server is running)
- [ ] `.claude/skills/worktree-setup/SKILL.md` is tracked in git
- [ ] `.claude/settings.local.json` remains untracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)