### PR TITLE
feat: Dynamic port derivation for E2E worktree parallelism

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -15,7 +15,7 @@ export const config = {
   archiveDir: process.env.ARCHIVE_DIR || join(homedir(), '.claude', 'plans', 'archive'),
 
   /** Allowed CORS origins */
-  corsOrigins: (process.env.CORS_ORIGINS || 'http://localhost:5173').split(','),
+  corsOrigins: (process.env.CORS_ORIGINS || `http://localhost:${process.env.WEB_PORT || '5173'}`).split(','),
 
   /** Maximum file size for plans (10MB) */
   maxFileSize: 10 * 1024 * 1024,

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -14,10 +14,11 @@ export default defineConfig({
     },
   },
   server: {
-    port: 5173,
+    port: parseInt(process.env.WEB_PORT || '5173', 10),
+    strictPort: true,
     proxy: {
       '/api': {
-        target: 'http://localhost:3001',
+        target: `http://localhost:${process.env.API_PORT || '3001'}`,
         changeOrigin: true,
       },
     },

--- a/e2e/lib/__tests__/ports.test.ts
+++ b/e2e/lib/__tests__/ports.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { derivePort, getApiPort, getWebPort } from '../ports.js';
+
+describe('derivePort', () => {
+  it('returns a port in range 10000-59999', () => {
+    const port = derivePort('/some/path', 0);
+    assert.ok(port >= 10000, `port ${port} should be >= 10000`);
+    assert.ok(port <= 59999, `port ${port} should be <= 59999`);
+  });
+
+  it('is deterministic for the same input', () => {
+    const a = derivePort('/same/path', 0);
+    const b = derivePort('/same/path', 0);
+    assert.equal(a, b);
+  });
+
+  it('produces different ports for different paths', () => {
+    const a = derivePort('/path/one', 0);
+    const b = derivePort('/path/two', 0);
+    assert.notEqual(a, b);
+  });
+
+  it('produces different ports for different offsets', () => {
+    const a = derivePort('/same/path', 0);
+    const b = derivePort('/same/path', 1);
+    assert.notEqual(a, b);
+  });
+});
+
+describe('getApiPort / getWebPort', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    delete process.env.API_PORT;
+    delete process.env.WEB_PORT;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('derives ports from cwd when env vars are not set', () => {
+    const apiPort = getApiPort('/test/worktree');
+    const webPort = getWebPort('/test/worktree');
+
+    assert.ok(typeof apiPort === 'number');
+    assert.ok(typeof webPort === 'number');
+    assert.ok(apiPort >= 10000);
+    assert.ok(webPort >= 10000);
+    assert.notEqual(apiPort, webPort);
+  });
+
+  it('API_PORT env var overrides derived port', () => {
+    process.env.API_PORT = '9001';
+    const port = getApiPort('/test/worktree');
+    assert.equal(port, 9001);
+  });
+
+  it('WEB_PORT env var overrides derived port', () => {
+    process.env.WEB_PORT = '9002';
+    const port = getWebPort('/test/worktree');
+    assert.equal(port, 9002);
+  });
+
+  it('derived API port never equals 3001', () => {
+    // Test many paths to increase confidence
+    for (let i = 0; i < 100; i++) {
+      const port = getApiPort(`/test/path/${i}`);
+      assert.notEqual(port, 3001, `path /test/path/${i} derived API port 3001`);
+    }
+  });
+
+  it('derived WEB port never equals 5173', () => {
+    for (let i = 0; i < 100; i++) {
+      const port = getWebPort(`/test/path/${i}`);
+      assert.notEqual(port, 5173, `path /test/path/${i} derived WEB port 5173`);
+    }
+  });
+
+  it('is deterministic across calls', () => {
+    const cwd = '/Users/tanabe/worktrees/feature-a';
+    assert.equal(getApiPort(cwd), getApiPort(cwd));
+    assert.equal(getWebPort(cwd), getWebPort(cwd));
+  });
+});

--- a/e2e/lib/ports.ts
+++ b/e2e/lib/ports.ts
@@ -1,0 +1,42 @@
+import { createHash } from 'node:crypto';
+
+const PORT_RANGE_START = 10000;
+const PORT_RANGE_SIZE = 50000;
+const DEV_API_PORT = 3001;
+const DEV_WEB_PORT = 5173;
+
+/**
+ * Derive a deterministic port from a path string and offset.
+ * Range: 10000-59999. Avoids dev server defaults (3001, 5173).
+ */
+export function derivePort(path: string, offset: number): number {
+  const hash = createHash('md5').update(`${path}:${offset}`).digest('hex');
+  const num = parseInt(hash.slice(0, 8), 16);
+  let port = (num % PORT_RANGE_SIZE) + PORT_RANGE_START;
+
+  if (port === DEV_API_PORT || port === DEV_WEB_PORT) {
+    port += 2;
+  }
+
+  return port;
+}
+
+/**
+ * Get API port: env var API_PORT or derived from worktree path.
+ */
+export function getApiPort(cwd?: string): number {
+  if (process.env.API_PORT) {
+    return parseInt(process.env.API_PORT, 10);
+  }
+  return derivePort(cwd ?? process.cwd(), 0);
+}
+
+/**
+ * Get Web port: env var WEB_PORT or derived from worktree path.
+ */
+export function getWebPort(cwd?: string): number {
+  if (process.env.WEB_PORT) {
+    return parseInt(process.env.WEB_PORT, 10);
+  }
+  return derivePort(cwd ?? process.cwd(), 1);
+}

--- a/e2e/lib/test-helpers.ts
+++ b/e2e/lib/test-helpers.ts
@@ -1,0 +1,3 @@
+import { getApiPort } from './ports.js';
+
+export const API_BASE_URL = `http://localhost:${getApiPort()}`;

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,10 +1,14 @@
 import { defineConfig, devices } from '@playwright/test';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { getApiPort, getWebPort } from './lib/ports.js';
 
 // Use fixtures directory for tests
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const fixturesDir = resolve(__dirname, 'fixtures', 'plans');
+
+const apiPort = getApiPort();
+const webPort = getWebPort();
 
 export default defineConfig({
   testDir: './tests',
@@ -14,7 +18,7 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
   reporter: 'html',
   use: {
-    baseURL: 'http://localhost:5173',
+    baseURL: `http://localhost:${webPort}`,
     trace: 'on-first-retry',
   },
   projects: [
@@ -27,19 +31,25 @@ export default defineConfig({
     {
       command: 'pnpm --filter @ccplans/api dev',
       cwd: '..',
-      url: 'http://localhost:3001/api/health',
+      url: `http://localhost:${apiPort}/api/health`,
       reuseExistingServer: false,
       timeout: 120 * 1000,
       env: {
         PLANS_DIR: fixturesDir,
+        PORT: String(apiPort),
+        CORS_ORIGINS: `http://localhost:${webPort}`,
       },
     },
     {
       command: 'pnpm --filter @ccplans/web dev',
       cwd: '..',
-      url: 'http://localhost:5173',
+      url: `http://localhost:${webPort}`,
       reuseExistingServer: false,
       timeout: 120 * 1000,
+      env: {
+        WEB_PORT: String(webPort),
+        API_PORT: String(apiPort),
+      },
     },
   ],
 });

--- a/e2e/tests/advanced-search.spec.ts
+++ b/e2e/tests/advanced-search.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { API_BASE_URL } from '../lib/test-helpers';
 
 // Run tests serially to avoid state conflicts
 test.describe.configure({ mode: 'serial' });
@@ -18,7 +19,7 @@ test.describe('Advanced Search (Feature 6)', () => {
   });
 
   test('API: status:todo filter search should work', async ({ request }) => {
-    const response = await request.get('http://localhost:3001/api/search', {
+    const response = await request.get(`${API_BASE_URL}/api/search`, {
       params: { q: 'status:todo' },
     });
 
@@ -36,7 +37,7 @@ test.describe('Advanced Search (Feature 6)', () => {
   });
 
   test('API: tag:api filter search should work', async ({ request }) => {
-    const response = await request.get('http://localhost:3001/api/search', {
+    const response = await request.get(`${API_BASE_URL}/api/search`, {
       params: { q: 'tag:api' },
     });
 
@@ -53,7 +54,7 @@ test.describe('Advanced Search (Feature 6)', () => {
   });
 
   test('API: priority:high filter search should work', async ({ request }) => {
-    const response = await request.get('http://localhost:3001/api/search', {
+    const response = await request.get(`${API_BASE_URL}/api/search`, {
       params: { q: 'priority:high' },
     });
 
@@ -70,7 +71,7 @@ test.describe('Advanced Search (Feature 6)', () => {
   });
 
   test('API: assignee:alice filter search should work', async ({ request }) => {
-    const response = await request.get('http://localhost:3001/api/search', {
+    const response = await request.get(`${API_BASE_URL}/api/search`, {
       params: { q: 'assignee:alice' },
     });
 
@@ -88,7 +89,7 @@ test.describe('Advanced Search (Feature 6)', () => {
   });
 
   test('API: combined query (text + filter) should work', async ({ request }) => {
-    const response = await request.get('http://localhost:3001/api/search', {
+    const response = await request.get(`${API_BASE_URL}/api/search`, {
       params: { q: 'auth status:todo' },
     });
 
@@ -128,7 +129,7 @@ test.describe('Advanced Search (Feature 6)', () => {
   });
 
   test('API: due date less than filter should work', async ({ request }) => {
-    const response = await request.get('http://localhost:3001/api/search', {
+    const response = await request.get(`${API_BASE_URL}/api/search`, {
       params: { q: 'due<2026-02-07' },
     });
 
@@ -145,7 +146,7 @@ test.describe('Advanced Search (Feature 6)', () => {
   });
 
   test('API: due date greater than filter should work', async ({ request }) => {
-    const response = await request.get('http://localhost:3001/api/search', {
+    const response = await request.get(`${API_BASE_URL}/api/search`, {
       params: { q: 'due>2026-02-07' },
     });
 
@@ -161,7 +162,7 @@ test.describe('Advanced Search (Feature 6)', () => {
   });
 
   test('API: estimate filter should work', async ({ request }) => {
-    const response = await request.get('http://localhost:3001/api/search', {
+    const response = await request.get(`${API_BASE_URL}/api/search`, {
       params: { q: 'estimate:3d' },
     });
 
@@ -177,7 +178,7 @@ test.describe('Advanced Search (Feature 6)', () => {
   });
 
   test('API: project filter should work', async ({ request }) => {
-    const response = await request.get('http://localhost:3001/api/search', {
+    const response = await request.get(`${API_BASE_URL}/api/search`, {
       params: { q: 'project:/home/user/projects/web-app' },
     });
 
@@ -194,7 +195,7 @@ test.describe('Advanced Search (Feature 6)', () => {
   });
 
   test('API: blockedBy filter should work', async ({ request }) => {
-    const response = await request.get('http://localhost:3001/api/search', {
+    const response = await request.get(`${API_BASE_URL}/api/search`, {
       params: { q: 'blockedBy:blue-running-fox.md' },
     });
 
@@ -210,7 +211,7 @@ test.describe('Advanced Search (Feature 6)', () => {
   });
 
   test('API: quoted phrase search should work', async ({ request }) => {
-    const response = await request.get('http://localhost:3001/api/search', {
+    const response = await request.get(`${API_BASE_URL}/api/search`, {
       params: { q: '"Performance Optimization"' },
     });
 
@@ -226,7 +227,7 @@ test.describe('Advanced Search (Feature 6)', () => {
   });
 
   test('API: multiple combined filters should work', async ({ request }) => {
-    const response = await request.get('http://localhost:3001/api/search', {
+    const response = await request.get(`${API_BASE_URL}/api/search`, {
       params: { q: 'status:todo priority:high tag:backend' },
     });
 
@@ -245,7 +246,7 @@ test.describe('Advanced Search (Feature 6)', () => {
   });
 
   test('API: empty query should return validation error', async ({ request }) => {
-    const response = await request.get('http://localhost:3001/api/search', {
+    const response = await request.get(`${API_BASE_URL}/api/search`, {
       params: { q: '' },
     });
 

--- a/e2e/tests/bulk-operations.spec.ts
+++ b/e2e/tests/bulk-operations.spec.ts
@@ -1,9 +1,8 @@
 import { test, expect } from '@playwright/test';
+import { API_BASE_URL } from '../lib/test-helpers';
 
 // Run tests serially to avoid state conflicts
 test.describe.configure({ mode: 'serial' });
-
-const API_BASE_URL = 'http://localhost:3001';
 const BULK_TEST_FILES = ['bulk-test-1.md', 'bulk-test-2.md', 'bulk-test-3.md'];
 
 test.describe('Bulk Operations (Feature 5)', () => {

--- a/e2e/tests/delete.spec.ts
+++ b/e2e/tests/delete.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { API_BASE_URL } from '../lib/test-helpers';
 
 // Run tests serially to avoid state conflicts
 test.describe.configure({ mode: 'serial' });
@@ -41,7 +42,7 @@ async function clickDeleteMenuItem(page: import('@playwright/test').Page) {
 test.describe('Delete functionality (from detail page)', () => {
   test.beforeEach(async ({ request }) => {
     // Create a test plan via API before each test
-    await request.post('http://localhost:3001/api/plans', {
+    await request.post(`${API_BASE_URL}/api/plans`, {
       data: {
         filename: TEST_PLAN_FILENAME,
         content: TEST_PLAN_CONTENT,
@@ -51,9 +52,9 @@ test.describe('Delete functionality (from detail page)', () => {
 
   test.afterEach(async ({ request }) => {
     // Clean up: try to delete the test plan if it still exists
-    await request.delete(`http://localhost:3001/api/plans/${TEST_PLAN_FILENAME}`).catch(() => {});
+    await request.delete(`${API_BASE_URL}/api/plans/${TEST_PLAN_FILENAME}`).catch(() => {});
     // Also try to delete from archive
-    await request.delete(`http://localhost:3001/api/archive/${TEST_PLAN_FILENAME}`).catch(() => {});
+    await request.delete(`${API_BASE_URL}/api/archive/${TEST_PLAN_FILENAME}`).catch(() => {});
   });
 
   test('should show delete confirmation dialog on detail page', async ({ page }) => {
@@ -107,7 +108,7 @@ test.describe('Delete functionality (from detail page)', () => {
     await expect(page).toHaveURL('/', { timeout: 10000 });
 
     // Verify via API that plan no longer exists (should return 404)
-    const response = await request.get(`http://localhost:3001/api/plans/${TEST_PLAN_FILENAME}`);
+    const response = await request.get(`${API_BASE_URL}/api/plans/${TEST_PLAN_FILENAME}`);
     expect(response.status()).toBe(404);
   });
 
@@ -129,7 +130,7 @@ test.describe('Delete functionality (from detail page)', () => {
     await expect(page).toHaveURL(`/plan/${TEST_PLAN_FILENAME}`);
 
     // Verify via API that plan still exists
-    const response = await request.get(`http://localhost:3001/api/plans/${TEST_PLAN_FILENAME}`);
+    const response = await request.get(`${API_BASE_URL}/api/plans/${TEST_PLAN_FILENAME}`);
     expect(response.ok()).toBeTruthy();
   });
 });
@@ -140,7 +141,7 @@ test.describe('Bulk delete functionality', () => {
   test.beforeEach(async ({ request }) => {
     // Create test plans
     for (const filename of BULK_TEST_FILES) {
-      await request.post('http://localhost:3001/api/plans', {
+      await request.post(`${API_BASE_URL}/api/plans`, {
         data: {
           filename,
           content: `# ${filename}\n\nTest content for bulk delete.`,
@@ -152,7 +153,7 @@ test.describe('Bulk delete functionality', () => {
   test.afterEach(async ({ request }) => {
     // Clean up
     for (const filename of BULK_TEST_FILES) {
-      await request.delete(`http://localhost:3001/api/plans/${filename}`).catch(() => {});
+      await request.delete(`${API_BASE_URL}/api/plans/${filename}`).catch(() => {});
     }
   });
 
@@ -198,7 +199,7 @@ test.describe('Bulk delete functionality', () => {
 
     // Verify via API that plans no longer exist
     for (const filename of BULK_TEST_FILES) {
-      const response = await request.get(`http://localhost:3001/api/plans/${filename}`);
+      const response = await request.get(`${API_BASE_URL}/api/plans/${filename}`);
       expect(response.status()).toBe(404);
     }
   });

--- a/e2e/tests/dependencies.spec.ts
+++ b/e2e/tests/dependencies.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { API_BASE_URL } from '../lib/test-helpers';
 
 // Run tests serially to avoid state conflicts
 test.describe.configure({ mode: 'serial' });
@@ -14,7 +15,7 @@ test.describe('Dependencies functionality (Feature 13)', () => {
   });
 
   test('should retrieve dependency graph via API', async ({ request }) => {
-    const response = await request.get('http://localhost:3001/api/dependencies');
+    const response = await request.get(`${API_BASE_URL}/api/dependencies`);
     expect(response.ok()).toBeTruthy();
 
     const graph = await response.json();
@@ -27,7 +28,7 @@ test.describe('Dependencies functionality (Feature 13)', () => {
   });
 
   test('should show dependency relationship in graph', async ({ request }) => {
-    const response = await request.get('http://localhost:3001/api/dependencies');
+    const response = await request.get(`${API_BASE_URL}/api/dependencies`);
     expect(response.ok()).toBeTruthy();
 
     const graph = await response.json();
@@ -51,7 +52,7 @@ test.describe('Dependencies functionality (Feature 13)', () => {
 
   test('should retrieve dependencies for specific plan via API', async ({ request }) => {
     const response = await request.get(
-      'http://localhost:3001/api/dependencies/green-dancing-cat.md'
+      `${API_BASE_URL}/api/dependencies/green-dancing-cat.md`
     );
     expect(response.ok()).toBeTruthy();
 
@@ -96,7 +97,7 @@ test.describe('Dependencies functionality (Feature 13)', () => {
   });
 
   test('should detect no cycle in fixture dependencies', async ({ request }) => {
-    const response = await request.get('http://localhost:3001/api/dependencies');
+    const response = await request.get(`${API_BASE_URL}/api/dependencies`);
     expect(response.ok()).toBeTruthy();
 
     const graph = await response.json();
@@ -105,7 +106,7 @@ test.describe('Dependencies functionality (Feature 13)', () => {
   });
 
   test('should calculate critical path', async ({ request }) => {
-    const response = await request.get('http://localhost:3001/api/dependencies');
+    const response = await request.get(`${API_BASE_URL}/api/dependencies`);
     expect(response.ok()).toBeTruthy();
 
     const graph = await response.json();
@@ -121,7 +122,7 @@ test.describe('Dependencies functionality (Feature 13)', () => {
 
     try {
       // Create plan A that is blocked by plan B
-      await request.post('http://localhost:3001/api/plans', {
+      await request.post(`${API_BASE_URL}/api/plans`, {
         data: {
           filename: planA,
           content: `---
@@ -137,7 +138,7 @@ Depends on Plan B.
       });
 
       // Create plan B that is blocked by plan A (creating a cycle)
-      await request.post('http://localhost:3001/api/plans', {
+      await request.post(`${API_BASE_URL}/api/plans`, {
         data: {
           filename: planB,
           content: `---
@@ -153,22 +154,22 @@ Depends on Plan A.
       });
 
       // Check dependency graph for cycle
-      const response = await request.get('http://localhost:3001/api/dependencies');
+      const response = await request.get(`${API_BASE_URL}/api/dependencies`);
       expect(response.ok()).toBeTruthy();
 
       const graph = await response.json();
       expect(graph.hasCycle).toBe(true);
     } finally {
       // Clean up
-      await request.delete(`http://localhost:3001/api/plans/${planA}`).catch(() => {});
-      await request.delete(`http://localhost:3001/api/plans/${planB}`).catch(() => {});
+      await request.delete(`${API_BASE_URL}/api/plans/${planA}`).catch(() => {});
+      await request.delete(`${API_BASE_URL}/api/plans/${planB}`).catch(() => {});
     }
   });
 
   test('should show empty blockedBy/blocks for independent plan', async ({ request }) => {
     // red-sleeping-bear has no blockedBy in its frontmatter
     const response = await request.get(
-      'http://localhost:3001/api/dependencies/red-sleeping-bear.md'
+      `${API_BASE_URL}/api/dependencies/red-sleeping-bear.md`
     );
     expect(response.ok()).toBeTruthy();
 
@@ -185,7 +186,7 @@ Depends on Plan A.
 
     try {
       // Create a plan without dependencies
-      await request.post('http://localhost:3001/api/plans', {
+      await request.post(`${API_BASE_URL}/api/plans`, {
         data: {
           filename: testPlan,
           content: `---
@@ -199,13 +200,13 @@ No dependencies initially.
       });
 
       // Get initial graph - plan should have no dependencies
-      const initialResponse = await request.get(`http://localhost:3001/api/dependencies/${testPlan}`);
+      const initialResponse = await request.get(`${API_BASE_URL}/api/dependencies/${testPlan}`);
       expect(initialResponse.ok()).toBeTruthy();
       const initialData = await initialResponse.json();
       expect(initialData.blockedBy).toHaveLength(0);
 
       // Update the plan to add a dependency
-      await request.put(`http://localhost:3001/api/plans/${testPlan}`, {
+      await request.put(`${API_BASE_URL}/api/plans/${testPlan}`, {
         data: {
           content: `---
 status: todo
@@ -220,7 +221,7 @@ Now depends on blue-running-fox.
       });
 
       // Get updated graph - should show the new dependency
-      const updatedResponse = await request.get(`http://localhost:3001/api/dependencies/${testPlan}`);
+      const updatedResponse = await request.get(`${API_BASE_URL}/api/dependencies/${testPlan}`);
       expect(updatedResponse.ok()).toBeTruthy();
       const updatedData = await updatedResponse.json();
       // blockedBy is an array of DependencyNode objects with filename property
@@ -228,7 +229,7 @@ Now depends on blue-running-fox.
       expect(updatedBlockedByFilenames).toContain('blue-running-fox.md');
 
       // Also check full graph for the edge
-      const graphResponse = await request.get('http://localhost:3001/api/dependencies');
+      const graphResponse = await request.get(`${API_BASE_URL}/api/dependencies`);
       expect(graphResponse.ok()).toBeTruthy();
       const graph = await graphResponse.json();
       const edge = graph.edges.find(
@@ -236,7 +237,7 @@ Now depends on blue-running-fox.
       );
       expect(edge).toBeDefined();
     } finally {
-      await request.delete(`http://localhost:3001/api/plans/${testPlan}`).catch(() => {});
+      await request.delete(`${API_BASE_URL}/api/plans/${testPlan}`).catch(() => {});
     }
   });
 

--- a/e2e/tests/frontmatter-extended.spec.ts
+++ b/e2e/tests/frontmatter-extended.spec.ts
@@ -1,9 +1,8 @@
 import { test, expect } from '@playwright/test';
+import { API_BASE_URL } from '../lib/test-helpers';
 
 // Run tests serially to avoid state conflicts
 test.describe.configure({ mode: 'serial' });
-
-const API_BASE_URL = 'http://localhost:3001';
 const TEST_PLAN_FILENAME = 'test-frontmatter-plan.md';
 
 test.describe('Front Matter Extended Fields (Feature 1)', () => {

--- a/e2e/tests/history.spec.ts
+++ b/e2e/tests/history.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { API_BASE_URL } from '../lib/test-helpers';
 
 // Run tests serially to avoid state conflicts
 test.describe.configure({ mode: 'serial' });
@@ -26,7 +27,7 @@ This section was added in the update.
 test.describe('History & Rollback (Feature 10)', () => {
   test.beforeEach(async ({ request }) => {
     // Create a test plan
-    await request.post('http://localhost:3001/api/plans', {
+    await request.post(`${API_BASE_URL}/api/plans`, {
       data: {
         filename: TEST_PLAN_FILENAME,
         content: INITIAL_CONTENT,
@@ -36,18 +37,18 @@ test.describe('History & Rollback (Feature 10)', () => {
 
   test.afterEach(async ({ request }) => {
     // Clean up: delete the test plan
-    await request.delete(`http://localhost:3001/api/plans/${TEST_PLAN_FILENAME}`).catch(() => {});
+    await request.delete(`${API_BASE_URL}/api/plans/${TEST_PLAN_FILENAME}`).catch(() => {});
   });
 
   test('API: should save version history when plan is updated', async ({ request }) => {
     // Update the plan
-    await request.put(`http://localhost:3001/api/plans/${TEST_PLAN_FILENAME}`, {
+    await request.put(`${API_BASE_URL}/api/plans/${TEST_PLAN_FILENAME}`, {
       data: { content: UPDATED_CONTENT },
     });
 
     // Get history
     const historyResponse = await request.get(
-      `http://localhost:3001/api/plans/${TEST_PLAN_FILENAME}/history`
+      `${API_BASE_URL}/api/plans/${TEST_PLAN_FILENAME}/history`
     );
 
     expect(historyResponse.ok()).toBeTruthy();
@@ -67,16 +68,16 @@ test.describe('History & Rollback (Feature 10)', () => {
 
   test('API: should retrieve version history list', async ({ request }) => {
     // Update plan twice to create multiple versions
-    await request.put(`http://localhost:3001/api/plans/${TEST_PLAN_FILENAME}`, {
+    await request.put(`${API_BASE_URL}/api/plans/${TEST_PLAN_FILENAME}`, {
       data: { content: UPDATED_CONTENT },
     });
 
-    await request.put(`http://localhost:3001/api/plans/${TEST_PLAN_FILENAME}`, {
+    await request.put(`${API_BASE_URL}/api/plans/${TEST_PLAN_FILENAME}`, {
       data: { content: UPDATED_CONTENT + '\n\n## Another Update\nMore changes.' },
     });
 
     // Get history
-    const response = await request.get(`http://localhost:3001/api/plans/${TEST_PLAN_FILENAME}/history`);
+    const response = await request.get(`${API_BASE_URL}/api/plans/${TEST_PLAN_FILENAME}/history`);
 
     expect(response.ok()).toBeTruthy();
     const data = await response.json();
@@ -92,13 +93,13 @@ test.describe('History & Rollback (Feature 10)', () => {
 
   test('API: should get content of a specific version', async ({ request }) => {
     // Update the plan to create a version
-    await request.put(`http://localhost:3001/api/plans/${TEST_PLAN_FILENAME}`, {
+    await request.put(`${API_BASE_URL}/api/plans/${TEST_PLAN_FILENAME}`, {
       data: { content: UPDATED_CONTENT },
     });
 
     // Get history to find a version
     const historyResponse = await request.get(
-      `http://localhost:3001/api/plans/${TEST_PLAN_FILENAME}/history`
+      `${API_BASE_URL}/api/plans/${TEST_PLAN_FILENAME}/history`
     );
     const historyData = await historyResponse.json();
 
@@ -109,7 +110,7 @@ test.describe('History & Rollback (Feature 10)', () => {
 
     // Get the specific version content
     const versionResponse = await request.get(
-      `http://localhost:3001/api/plans/${TEST_PLAN_FILENAME}/history/${encodeURIComponent(version)}`
+      `${API_BASE_URL}/api/plans/${TEST_PLAN_FILENAME}/history/${encodeURIComponent(version)}`
     );
 
     expect(versionResponse.ok()).toBeTruthy();
@@ -123,13 +124,13 @@ test.describe('History & Rollback (Feature 10)', () => {
 
   test('API: should compute diff between two versions', async ({ request }) => {
     // Update the plan to create a version
-    await request.put(`http://localhost:3001/api/plans/${TEST_PLAN_FILENAME}`, {
+    await request.put(`${API_BASE_URL}/api/plans/${TEST_PLAN_FILENAME}`, {
       data: { content: UPDATED_CONTENT },
     });
 
     // Get history
     const historyResponse = await request.get(
-      `http://localhost:3001/api/plans/${TEST_PLAN_FILENAME}/history`
+      `${API_BASE_URL}/api/plans/${TEST_PLAN_FILENAME}/history`
     );
     const historyData = await historyResponse.json();
 
@@ -140,7 +141,7 @@ test.describe('History & Rollback (Feature 10)', () => {
 
     // Get diff between version and current
     const diffResponse = await request.get(
-      `http://localhost:3001/api/plans/${TEST_PLAN_FILENAME}/diff?from=${encodeURIComponent(version)}`
+      `${API_BASE_URL}/api/plans/${TEST_PLAN_FILENAME}/diff?from=${encodeURIComponent(version)}`
     );
 
     expect(diffResponse.ok()).toBeTruthy();
@@ -156,13 +157,13 @@ test.describe('History & Rollback (Feature 10)', () => {
 
   test('API: should rollback to a specific version', async ({ request }) => {
     // Update the plan to create a version
-    await request.put(`http://localhost:3001/api/plans/${TEST_PLAN_FILENAME}`, {
+    await request.put(`${API_BASE_URL}/api/plans/${TEST_PLAN_FILENAME}`, {
       data: { content: UPDATED_CONTENT },
     });
 
     // Get history
     const historyResponse = await request.get(
-      `http://localhost:3001/api/plans/${TEST_PLAN_FILENAME}/history`
+      `${API_BASE_URL}/api/plans/${TEST_PLAN_FILENAME}/history`
     );
     const historyData = await historyResponse.json();
 
@@ -173,7 +174,7 @@ test.describe('History & Rollback (Feature 10)', () => {
 
     // Rollback to that version
     const rollbackResponse = await request.post(
-      `http://localhost:3001/api/plans/${TEST_PLAN_FILENAME}/rollback`,
+      `${API_BASE_URL}/api/plans/${TEST_PLAN_FILENAME}/rollback`,
       {
         data: { version },
       }
@@ -184,12 +185,12 @@ test.describe('History & Rollback (Feature 10)', () => {
     expect(rollbackData.success).toBe(true);
 
     // Verify the current content matches the rolled-back version
-    const currentResponse = await request.get(`http://localhost:3001/api/plans/${TEST_PLAN_FILENAME}`);
+    const currentResponse = await request.get(`${API_BASE_URL}/api/plans/${TEST_PLAN_FILENAME}`);
     const currentData = await currentResponse.json();
 
     // Get the version content
     const versionResponse = await request.get(
-      `http://localhost:3001/api/plans/${TEST_PLAN_FILENAME}/history/${encodeURIComponent(version)}`
+      `${API_BASE_URL}/api/plans/${TEST_PLAN_FILENAME}/history/${encodeURIComponent(version)}`
     );
     const versionData = await versionResponse.json();
 
@@ -205,7 +206,7 @@ test.describe('History & Rollback (Feature 10)', () => {
 
   test('should show history panel when clicking history tab', async ({ page }) => {
     // Update plan to create a version
-    await page.request.put(`http://localhost:3001/api/plans/${TEST_PLAN_FILENAME}`, {
+    await page.request.put(`${API_BASE_URL}/api/plans/${TEST_PLAN_FILENAME}`, {
       data: { content: UPDATED_CONTENT },
     });
 
@@ -229,11 +230,11 @@ test.describe('History & Rollback (Feature 10)', () => {
 
   test('should display version items in history panel', async ({ page }) => {
     // Update plan multiple times to create versions
-    await page.request.put(`http://localhost:3001/api/plans/${TEST_PLAN_FILENAME}`, {
+    await page.request.put(`${API_BASE_URL}/api/plans/${TEST_PLAN_FILENAME}`, {
       data: { content: UPDATED_CONTENT },
     });
 
-    await page.request.put(`http://localhost:3001/api/plans/${TEST_PLAN_FILENAME}`, {
+    await page.request.put(`${API_BASE_URL}/api/plans/${TEST_PLAN_FILENAME}`, {
       data: { content: UPDATED_CONTENT + '\n\n## Update 2\nMore changes.' },
     });
 
@@ -252,7 +253,7 @@ test.describe('History & Rollback (Feature 10)', () => {
 
   test('should show rollback confirmation dialog when clicking rollback button', async ({ page }) => {
     // Update plan to create a version
-    await page.request.put(`http://localhost:3001/api/plans/${TEST_PLAN_FILENAME}`, {
+    await page.request.put(`${API_BASE_URL}/api/plans/${TEST_PLAN_FILENAME}`, {
       data: { content: UPDATED_CONTENT },
     });
 
@@ -283,13 +284,13 @@ test.describe('History & Rollback (Feature 10)', () => {
 
   test('API: should auto-save history on status change', async ({ request }) => {
     // First do a GET to populate the conflict cache
-    await request.get(`http://localhost:3001/api/plans/${TEST_PLAN_FILENAME}`);
+    await request.get(`${API_BASE_URL}/api/plans/${TEST_PLAN_FILENAME}`);
 
     // Record time before status change
     const beforeChange = Date.now();
 
     // Change status (todo -> in_progress)
-    const statusResponse = await request.patch(`http://localhost:3001/api/plans/${TEST_PLAN_FILENAME}/status`, {
+    const statusResponse = await request.patch(`${API_BASE_URL}/api/plans/${TEST_PLAN_FILENAME}/status`, {
       data: { status: 'in_progress' },
     });
     expect(statusResponse.ok()).toBeTruthy();
@@ -299,7 +300,7 @@ test.describe('History & Rollback (Feature 10)', () => {
 
     // Check that the latest history version was created after our status change
     const afterHistoryResponse = await request.get(
-      `http://localhost:3001/api/plans/${TEST_PLAN_FILENAME}/history`
+      `${API_BASE_URL}/api/plans/${TEST_PLAN_FILENAME}/history`
     );
     const afterData = await afterHistoryResponse.json();
 
@@ -317,13 +318,13 @@ test.describe('History & Rollback (Feature 10)', () => {
 
   test('API: rollback should create "Before rollback" version', async ({ request }) => {
     // Update the plan to create a version
-    await request.put(`http://localhost:3001/api/plans/${TEST_PLAN_FILENAME}`, {
+    await request.put(`${API_BASE_URL}/api/plans/${TEST_PLAN_FILENAME}`, {
       data: { content: UPDATED_CONTENT },
     });
 
     // Get history
     const historyResponse = await request.get(
-      `http://localhost:3001/api/plans/${TEST_PLAN_FILENAME}/history`
+      `${API_BASE_URL}/api/plans/${TEST_PLAN_FILENAME}/history`
     );
     const historyData = await historyResponse.json();
 
@@ -335,13 +336,13 @@ test.describe('History & Rollback (Feature 10)', () => {
     const beforeRollback = Date.now();
 
     // Rollback
-    await request.post(`http://localhost:3001/api/plans/${TEST_PLAN_FILENAME}/rollback`, {
+    await request.post(`${API_BASE_URL}/api/plans/${TEST_PLAN_FILENAME}/rollback`, {
       data: { version },
     });
 
     // Check history for a version created after our rollback (the "Before rollback" save)
     const afterRollbackHistory = await request.get(
-      `http://localhost:3001/api/plans/${TEST_PLAN_FILENAME}/history`
+      `${API_BASE_URL}/api/plans/${TEST_PLAN_FILENAME}/history`
     );
     const afterData = await afterRollbackHistory.json();
 
@@ -353,10 +354,10 @@ test.describe('History & Rollback (Feature 10)', () => {
 
   test('should execute rollback via UI and verify content', async ({ page }) => {
     // GET the plan first to refresh the conflict detection cache
-    await page.request.get(`http://localhost:3001/api/plans/${TEST_PLAN_FILENAME}`);
+    await page.request.get(`${API_BASE_URL}/api/plans/${TEST_PLAN_FILENAME}`);
 
     // Update plan to create a version
-    const updateResponse = await page.request.put(`http://localhost:3001/api/plans/${TEST_PLAN_FILENAME}`, {
+    const updateResponse = await page.request.put(`${API_BASE_URL}/api/plans/${TEST_PLAN_FILENAME}`, {
       data: { content: UPDATED_CONTENT },
     });
     expect(updateResponse.ok()).toBeTruthy();
@@ -398,13 +399,13 @@ test.describe('History & Rollback (Feature 10)', () => {
 
   test('API: should show diff with correct line types', async ({ request }) => {
     // Update the plan to create a version
-    await request.put(`http://localhost:3001/api/plans/${TEST_PLAN_FILENAME}`, {
+    await request.put(`${API_BASE_URL}/api/plans/${TEST_PLAN_FILENAME}`, {
       data: { content: UPDATED_CONTENT },
     });
 
     // Get history
     const historyResponse = await request.get(
-      `http://localhost:3001/api/plans/${TEST_PLAN_FILENAME}/history`
+      `${API_BASE_URL}/api/plans/${TEST_PLAN_FILENAME}/history`
     );
     const historyData = await historyResponse.json();
 
@@ -414,7 +415,7 @@ test.describe('History & Rollback (Feature 10)', () => {
 
     // Get diff between version and current
     const diffResponse = await request.get(
-      `http://localhost:3001/api/plans/${TEST_PLAN_FILENAME}/diff?from=${encodeURIComponent(version)}`
+      `${API_BASE_URL}/api/plans/${TEST_PLAN_FILENAME}/diff?from=${encodeURIComponent(version)}`
     );
 
     expect(diffResponse.ok()).toBeTruthy();
@@ -436,13 +437,13 @@ test.describe('History & Rollback (Feature 10)', () => {
 
   test('API: diff should include stats (added/removed/unchanged counts)', async ({ request }) => {
     // Update the plan to create a version
-    await request.put(`http://localhost:3001/api/plans/${TEST_PLAN_FILENAME}`, {
+    await request.put(`${API_BASE_URL}/api/plans/${TEST_PLAN_FILENAME}`, {
       data: { content: UPDATED_CONTENT },
     });
 
     // Get history
     const historyResponse = await request.get(
-      `http://localhost:3001/api/plans/${TEST_PLAN_FILENAME}/history`
+      `${API_BASE_URL}/api/plans/${TEST_PLAN_FILENAME}/history`
     );
     const historyData = await historyResponse.json();
 
@@ -452,7 +453,7 @@ test.describe('History & Rollback (Feature 10)', () => {
 
     // Get diff
     const diffResponse = await request.get(
-      `http://localhost:3001/api/plans/${TEST_PLAN_FILENAME}/diff?from=${encodeURIComponent(version)}`
+      `${API_BASE_URL}/api/plans/${TEST_PLAN_FILENAME}/diff?from=${encodeURIComponent(version)}`
     );
 
     expect(diffResponse.ok()).toBeTruthy();

--- a/e2e/tests/import-export.spec.ts
+++ b/e2e/tests/import-export.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { API_BASE_URL } from '../lib/test-helpers';
 
 // Run tests serially to avoid state conflicts
 test.describe.configure({ mode: 'serial' });
@@ -23,11 +24,11 @@ Testing markdown import.
 test.describe('Import/Export functionality (Feature 14)', () => {
   test.afterEach(async ({ request }) => {
     // Clean up: try to delete imported plans
-    await request.delete(`http://localhost:3001/api/plans/${TEST_IMPORT_FILENAME}`).catch(() => {});
+    await request.delete(`${API_BASE_URL}/api/plans/${TEST_IMPORT_FILENAME}`).catch(() => {});
   });
 
   test('should export plans as JSON via API', async ({ request }) => {
-    const response = await request.get('http://localhost:3001/api/export?format=json');
+    const response = await request.get(`${API_BASE_URL}/api/export?format=json`);
     expect(response.ok()).toBeTruthy();
 
     const contentType = response.headers()['content-type'];
@@ -40,7 +41,7 @@ test.describe('Import/Export functionality (Feature 14)', () => {
   });
 
   test('should export plans as CSV via API', async ({ request }) => {
-    const response = await request.get('http://localhost:3001/api/export?format=csv');
+    const response = await request.get(`${API_BASE_URL}/api/export?format=csv`);
     expect(response.ok()).toBeTruthy();
 
     const contentType = response.headers()['content-type'];
@@ -53,7 +54,7 @@ test.describe('Import/Export functionality (Feature 14)', () => {
   });
 
   test('should export plans as tar.gz via API', async ({ request }) => {
-    const response = await request.get('http://localhost:3001/api/export?format=zip');
+    const response = await request.get(`${API_BASE_URL}/api/export?format=zip`);
     expect(response.ok()).toBeTruthy();
 
     const contentType = response.headers()['content-type'];
@@ -64,7 +65,7 @@ test.describe('Import/Export functionality (Feature 14)', () => {
   });
 
   test('should import markdown files via API', async ({ request }) => {
-    const response = await request.post('http://localhost:3001/api/import/markdown', {
+    const response = await request.post(`${API_BASE_URL}/api/import/markdown`, {
       data: {
         files: [
           {
@@ -83,12 +84,12 @@ test.describe('Import/Export functionality (Feature 14)', () => {
     expect(Array.isArray(result.errors)).toBeTruthy();
 
     // Verify imported plan exists
-    const planResponse = await request.get(`http://localhost:3001/api/plans/${TEST_IMPORT_FILENAME}`);
+    const planResponse = await request.get(`${API_BASE_URL}/api/plans/${TEST_IMPORT_FILENAME}`);
     expect(planResponse.ok()).toBeTruthy();
   });
 
   test('should create backup via API', async ({ request }) => {
-    const response = await request.post('http://localhost:3001/api/backup');
+    const response = await request.post(`${API_BASE_URL}/api/backup`);
     expect(response.status()).toBe(201);
 
     const backup = await response.json();
@@ -101,10 +102,10 @@ test.describe('Import/Export functionality (Feature 14)', () => {
 
   test('should retrieve backup list via API', async ({ request }) => {
     // Create a backup first
-    await request.post('http://localhost:3001/api/backup');
+    await request.post(`${API_BASE_URL}/api/backup`);
 
     // Get backup list
-    const response = await request.get('http://localhost:3001/api/backups');
+    const response = await request.get(`${API_BASE_URL}/api/backups`);
     expect(response.ok()).toBeTruthy();
 
     const data = await response.json();
@@ -140,7 +141,7 @@ test.describe('Import/Export functionality (Feature 14)', () => {
   });
 
   test('should filter export by status', async ({ request }) => {
-    const response = await request.get('http://localhost:3001/api/export?format=json&filterStatus=todo');
+    const response = await request.get(`${API_BASE_URL}/api/export?format=json&filterStatus=todo`);
     expect(response.ok()).toBeTruthy();
 
     const json = await response.json();
@@ -155,7 +156,7 @@ test.describe('Import/Export functionality (Feature 14)', () => {
 
   test('should skip duplicate files on import', async ({ request }) => {
     // First import
-    const firstResponse = await request.post('http://localhost:3001/api/import/markdown', {
+    const firstResponse = await request.post(`${API_BASE_URL}/api/import/markdown`, {
       data: {
         files: [
           {
@@ -170,7 +171,7 @@ test.describe('Import/Export functionality (Feature 14)', () => {
     expect(firstResult.imported).toBeGreaterThan(0);
 
     // Second import of the same file should be skipped
-    const secondResponse = await request.post('http://localhost:3001/api/import/markdown', {
+    const secondResponse = await request.post(`${API_BASE_URL}/api/import/markdown`, {
       data: {
         files: [
           {
@@ -187,7 +188,7 @@ test.describe('Import/Export functionality (Feature 14)', () => {
 
   test('should export individual plan as markdown via API', async ({ request }) => {
     const response = await request.get(
-      'http://localhost:3001/api/plans/blue-running-fox.md/export?format=md'
+      `${API_BASE_URL}/api/plans/blue-running-fox.md/export?format=md`
     );
     expect(response.ok()).toBeTruthy();
 
@@ -203,7 +204,7 @@ test.describe('Import/Export functionality (Feature 14)', () => {
 
   test('should export individual plan as HTML via API', async ({ request }) => {
     const response = await request.get(
-      'http://localhost:3001/api/plans/blue-running-fox.md/export?format=html'
+      `${API_BASE_URL}/api/plans/blue-running-fox.md/export?format=html`
     );
     expect(response.ok()).toBeTruthy();
 
@@ -217,7 +218,7 @@ test.describe('Import/Export functionality (Feature 14)', () => {
 
   test('should return 501 for PDF export', async ({ request }) => {
     const response = await request.get(
-      'http://localhost:3001/api/plans/blue-running-fox.md/export?format=pdf'
+      `${API_BASE_URL}/api/plans/blue-running-fox.md/export?format=pdf`
     );
     expect(response.status()).toBe(501);
 
@@ -227,14 +228,14 @@ test.describe('Import/Export functionality (Feature 14)', () => {
 
   test('should restore from backup via API', async ({ request }) => {
     // Create a backup first
-    const backupResponse = await request.post('http://localhost:3001/api/backup');
+    const backupResponse = await request.post(`${API_BASE_URL}/api/backup`);
     expect(backupResponse.status()).toBe(201);
     const backup = await backupResponse.json();
     expect(backup.id).toBeDefined();
 
     // Restore from the backup
     const restoreResponse = await request.post(
-      `http://localhost:3001/api/backup/${backup.id}/restore`
+      `${API_BASE_URL}/api/backup/${backup.id}/restore`
     );
     expect(restoreResponse.ok()).toBeTruthy();
 
@@ -246,7 +247,7 @@ test.describe('Import/Export functionality (Feature 14)', () => {
 
   test('should filter export by tags', async ({ request }) => {
     const response = await request.get(
-      'http://localhost:3001/api/export?format=json&filterTags=backend'
+      `${API_BASE_URL}/api/export?format=json&filterTags=backend`
     );
     expect(response.ok()).toBeTruthy();
 
@@ -262,7 +263,7 @@ test.describe('Import/Export functionality (Feature 14)', () => {
 
   test('should display backup page with backup list', async ({ page, request }) => {
     // Ensure at least one backup exists
-    await request.post('http://localhost:3001/api/backup');
+    await request.post(`${API_BASE_URL}/api/backup`);
 
     // Navigate to backups page
     await page.goto('/backups');

--- a/e2e/tests/notifications.spec.ts
+++ b/e2e/tests/notifications.spec.ts
@@ -1,11 +1,12 @@
 import { test, expect } from '@playwright/test';
+import { API_BASE_URL } from '../lib/test-helpers';
 
 // Run tests serially to avoid state conflicts
 test.describe.configure({ mode: 'serial' });
 
 test.describe('Notifications (Feature 9)', () => {
   test('API: should retrieve notifications list', async ({ request }) => {
-    const response = await request.get('http://localhost:3001/api/notifications');
+    const response = await request.get(`${API_BASE_URL}/api/notifications`);
 
     expect(response.ok()).toBeTruthy();
     const data = await response.json();
@@ -17,7 +18,7 @@ test.describe('Notifications (Feature 9)', () => {
   });
 
   test('API: should generate overdue notification for past due date', async ({ request }) => {
-    const response = await request.get('http://localhost:3001/api/notifications');
+    const response = await request.get(`${API_BASE_URL}/api/notifications`);
 
     expect(response.ok()).toBeTruthy();
     const data = await response.json();
@@ -33,7 +34,7 @@ test.describe('Notifications (Feature 9)', () => {
   });
 
   test('API: should generate due soon notification for upcoming deadlines', async ({ request }) => {
-    const response = await request.get('http://localhost:3001/api/notifications');
+    const response = await request.get(`${API_BASE_URL}/api/notifications`);
 
     expect(response.ok()).toBeTruthy();
     const data = await response.json();
@@ -51,7 +52,7 @@ test.describe('Notifications (Feature 9)', () => {
 
   test('API: should mark notification as read', async ({ request }) => {
     // Get notifications - fixture data has overdue plans so notifications must exist
-    const listResponse = await request.get('http://localhost:3001/api/notifications');
+    const listResponse = await request.get(`${API_BASE_URL}/api/notifications`);
     const listData = await listResponse.json();
 
     expect(listData.notifications.length).toBeGreaterThan(0);
@@ -60,7 +61,7 @@ test.describe('Notifications (Feature 9)', () => {
 
     // Mark as read
     const readResponse = await request.patch(
-      `http://localhost:3001/api/notifications/${notificationId}/read`
+      `${API_BASE_URL}/api/notifications/${notificationId}/read`
     );
 
     expect(readResponse.ok()).toBeTruthy();
@@ -68,7 +69,7 @@ test.describe('Notifications (Feature 9)', () => {
     expect(readData.success).toBe(true);
 
     // Verify notification is marked as read
-    const verifyResponse = await request.get('http://localhost:3001/api/notifications');
+    const verifyResponse = await request.get(`${API_BASE_URL}/api/notifications`);
     const verifyData = await verifyResponse.json();
 
     const notification = verifyData.notifications.find((n: any) => n.id === notificationId);
@@ -77,14 +78,14 @@ test.describe('Notifications (Feature 9)', () => {
 
   test('API: should mark all notifications as read', async ({ request }) => {
     // Mark all as read
-    const response = await request.post('http://localhost:3001/api/notifications/mark-all-read');
+    const response = await request.post(`${API_BASE_URL}/api/notifications/mark-all-read`);
 
     expect(response.ok()).toBeTruthy();
     const data = await response.json();
     expect(data.success).toBe(true);
 
     // Verify all are read
-    const verifyResponse = await request.get('http://localhost:3001/api/notifications');
+    const verifyResponse = await request.get(`${API_BASE_URL}/api/notifications`);
     const verifyData = await verifyResponse.json();
 
     const allRead = verifyData.notifications.every((n: any) => n.read === true);
@@ -166,7 +167,7 @@ test.describe('Notifications (Feature 9)', () => {
   });
 
   test('API: should sort notifications by severity (critical first)', async ({ request }) => {
-    const response = await request.get('http://localhost:3001/api/notifications');
+    const response = await request.get(`${API_BASE_URL}/api/notifications`);
 
     expect(response.ok()).toBeTruthy();
     const data = await response.json();
@@ -204,7 +205,7 @@ test.describe('Notifications (Feature 9)', () => {
 
   test('should mark notification as read via UI', async ({ page }) => {
     // First, reset notifications so there are unread ones
-    await page.request.post('http://localhost:3001/api/notifications/mark-all-read').catch(() => {});
+    await page.request.post(`${API_BASE_URL}/api/notifications/mark-all-read`).catch(() => {});
 
     await page.goto('/');
     await expect(page.getByRole('heading', { name: 'プラン一覧' })).toBeVisible();
@@ -224,7 +225,7 @@ test.describe('Notifications (Feature 9)', () => {
   });
 
   test('API: should not generate notification for completed plans', async ({ request }) => {
-    const response = await request.get('http://localhost:3001/api/notifications');
+    const response = await request.get(`${API_BASE_URL}/api/notifications`);
 
     expect(response.ok()).toBeTruthy();
     const data = await response.json();
@@ -240,7 +241,7 @@ test.describe('Notifications (Feature 9)', () => {
   // Skip: green-dancing-cat's modified date gets updated by other tests (status changes),
   // so it may not be stale (3+ days old) when this test runs.
   test.skip('API: blocked_stale notification for stale blocked plans', async ({ request }) => {
-    const response = await request.get('http://localhost:3001/api/notifications');
+    const response = await request.get(`${API_BASE_URL}/api/notifications`);
 
     expect(response.ok()).toBeTruthy();
     const data = await response.json();

--- a/e2e/tests/plan-rendering.spec.ts
+++ b/e2e/tests/plan-rendering.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { API_BASE_URL } from '../lib/test-helpers';
 
 test.describe.configure({ mode: 'serial' });
 
@@ -40,7 +41,7 @@ function add(a: number, b: number): number {
 
 test.describe('Plan detail rendering', () => {
   test.beforeEach(async ({ request }) => {
-    await request.post('http://localhost:3001/api/plans', {
+    await request.post(`${API_BASE_URL}/api/plans`, {
       data: {
         filename: TEST_PLAN_FILENAME,
         content: TEST_PLAN_CONTENT,
@@ -49,7 +50,7 @@ test.describe('Plan detail rendering', () => {
   });
 
   test.afterEach(async ({ request }) => {
-    await request.delete(`http://localhost:3001/api/plans/${TEST_PLAN_FILENAME}`).catch(() => {});
+    await request.delete(`${API_BASE_URL}/api/plans/${TEST_PLAN_FILENAME}`).catch(() => {});
   });
 
   test('should not display YAML frontmatter in rendered content', async ({ page }) => {

--- a/e2e/tests/quality-ops.spec.ts
+++ b/e2e/tests/quality-ops.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { API_BASE_URL } from '../lib/test-helpers';
 
 // Run tests serially to avoid state conflicts
 test.describe.configure({ mode: 'serial' });
@@ -15,7 +16,7 @@ Testing audit log, schema version, and migration.
 test.describe('Quality & Operations functionality (Feature 15)', () => {
   test.beforeEach(async ({ request }) => {
     // Create a test plan via API
-    await request.post('http://localhost:3001/api/plans', {
+    await request.post(`${API_BASE_URL}/api/plans`, {
       data: {
         filename: TEST_PLAN_FILENAME,
         content: TEST_PLAN_CONTENT,
@@ -25,11 +26,11 @@ test.describe('Quality & Operations functionality (Feature 15)', () => {
 
   test.afterEach(async ({ request }) => {
     // Clean up: try to delete the test plan if it still exists
-    await request.delete(`http://localhost:3001/api/plans/${TEST_PLAN_FILENAME}`).catch(() => {});
+    await request.delete(`${API_BASE_URL}/api/plans/${TEST_PLAN_FILENAME}`).catch(() => {});
   });
 
   test('should retrieve audit log via API', async ({ request }) => {
-    const response = await request.get('http://localhost:3001/api/admin/audit');
+    const response = await request.get(`${API_BASE_URL}/api/admin/audit`);
     expect(response.ok()).toBeTruthy();
 
     const data = await response.json();
@@ -47,7 +48,7 @@ test.describe('Quality & Operations functionality (Feature 15)', () => {
   });
 
   test('should retrieve schema version via API', async ({ request }) => {
-    const response = await request.get('http://localhost:3001/api/admin/schema-version');
+    const response = await request.get(`${API_BASE_URL}/api/admin/schema-version`);
     expect(response.ok()).toBeTruthy();
 
     const data = await response.json();
@@ -57,7 +58,7 @@ test.describe('Quality & Operations functionality (Feature 15)', () => {
   });
 
   test('should run migration via API', async ({ request }) => {
-    const response = await request.post('http://localhost:3001/api/admin/migrate');
+    const response = await request.post(`${API_BASE_URL}/api/admin/migrate`);
     expect(response.ok()).toBeTruthy();
 
     const result = await response.json();
@@ -70,12 +71,12 @@ test.describe('Quality & Operations functionality (Feature 15)', () => {
   test('should detect conflict on concurrent update (mtime-based)', async ({ request }) => {
     // Use status update to set the modified field in frontmatter
     // (updateStatus sets modified automatically)
-    await request.patch(`http://localhost:3001/api/plans/${TEST_PLAN_FILENAME}/status`, {
+    await request.patch(`${API_BASE_URL}/api/plans/${TEST_PLAN_FILENAME}/status`, {
       data: { status: 'in_progress' },
     });
 
     // Get current plan details (now has modified in frontmatter from the status change)
-    const getResponse = await request.get(`http://localhost:3001/api/plans/${TEST_PLAN_FILENAME}`);
+    const getResponse = await request.get(`${API_BASE_URL}/api/plans/${TEST_PLAN_FILENAME}`);
     expect(getResponse.ok()).toBeTruthy();
     const plan = await getResponse.json();
     const originalMtime = plan.frontmatter?.modified;
@@ -85,12 +86,12 @@ test.describe('Quality & Operations functionality (Feature 15)', () => {
     await new Promise((resolve) => setTimeout(resolve, 1100));
 
     // Use another status update to trigger modified change
-    await request.patch(`http://localhost:3001/api/plans/${TEST_PLAN_FILENAME}/status`, {
+    await request.patch(`${API_BASE_URL}/api/plans/${TEST_PLAN_FILENAME}/status`, {
       data: { status: 'review' },
     });
 
     // Get updated plan
-    const updatedResponse = await request.get(`http://localhost:3001/api/plans/${TEST_PLAN_FILENAME}`);
+    const updatedResponse = await request.get(`${API_BASE_URL}/api/plans/${TEST_PLAN_FILENAME}`);
     expect(updatedResponse.ok()).toBeTruthy();
     const updatedPlan = await updatedResponse.json();
     const newMtime = updatedPlan.frontmatter?.modified;
@@ -102,7 +103,7 @@ test.describe('Quality & Operations functionality (Feature 15)', () => {
 
   test('should record audit log on plan operations', async ({ request }) => {
     // Get initial audit log count
-    const initialResponse = await request.get('http://localhost:3001/api/admin/audit');
+    const initialResponse = await request.get(`${API_BASE_URL}/api/admin/audit`);
     expect(initialResponse.ok()).toBeTruthy();
     const initialData = await initialResponse.json();
     const initialCount = initialData.entries.length;
@@ -111,7 +112,7 @@ test.describe('Quality & Operations functionality (Feature 15)', () => {
     const testFilename = 'test-audit-log-plan.md';
 
     // Create
-    await request.post('http://localhost:3001/api/plans', {
+    await request.post(`${API_BASE_URL}/api/plans`, {
       data: {
         filename: testFilename,
         content: '# Test Audit\n\nTesting audit log.',
@@ -119,17 +120,17 @@ test.describe('Quality & Operations functionality (Feature 15)', () => {
     });
 
     // Update
-    await request.put(`http://localhost:3001/api/plans/${testFilename}`, {
+    await request.put(`${API_BASE_URL}/api/plans/${testFilename}`, {
       data: {
         content: '# Test Audit\n\nUpdated content.',
       },
     });
 
     // Delete
-    await request.delete(`http://localhost:3001/api/plans/${testFilename}`);
+    await request.delete(`${API_BASE_URL}/api/plans/${testFilename}`);
 
     // Get updated audit log
-    const finalResponse = await request.get('http://localhost:3001/api/admin/audit');
+    const finalResponse = await request.get(`${API_BASE_URL}/api/admin/audit`);
     expect(finalResponse.ok()).toBeTruthy();
     const finalData = await finalResponse.json();
     const finalCount = finalData.entries.length;
@@ -155,7 +156,7 @@ test.describe('Quality & Operations functionality (Feature 15)', () => {
 
   test('should filter audit log by filename', async ({ request }) => {
     const response = await request.get(
-      `http://localhost:3001/api/admin/audit?filename=${TEST_PLAN_FILENAME}`
+      `${API_BASE_URL}/api/admin/audit?filename=${TEST_PLAN_FILENAME}`
     );
     expect(response.ok()).toBeTruthy();
 
@@ -168,7 +169,7 @@ test.describe('Quality & Operations functionality (Feature 15)', () => {
   });
 
   test('should limit audit log results', async ({ request }) => {
-    const response = await request.get('http://localhost:3001/api/admin/audit?limit=5');
+    const response = await request.get(`${API_BASE_URL}/api/admin/audit?limit=5`);
     expect(response.ok()).toBeTruthy();
 
     const data = await response.json();
@@ -179,7 +180,7 @@ test.describe('Quality & Operations functionality (Feature 15)', () => {
   test('should filter audit log by action type', async ({ request }) => {
     // First ensure there are some 'create' entries by creating a plan
     const testFile = 'test-audit-filter-action.md';
-    await request.post('http://localhost:3001/api/plans', {
+    await request.post(`${API_BASE_URL}/api/plans`, {
       data: {
         filename: testFile,
         content: '# Audit Filter Test\n\nTesting action filter.',
@@ -187,7 +188,7 @@ test.describe('Quality & Operations functionality (Feature 15)', () => {
     });
 
     // Query audit log filtering by action=create
-    const response = await request.get('http://localhost:3001/api/admin/audit?action=create');
+    const response = await request.get(`${API_BASE_URL}/api/admin/audit?action=create`);
     expect(response.ok()).toBeTruthy();
 
     const data = await response.json();
@@ -199,13 +200,13 @@ test.describe('Quality & Operations functionality (Feature 15)', () => {
     }
 
     // Clean up
-    await request.delete(`http://localhost:3001/api/plans/${testFile}`).catch(() => {});
+    await request.delete(`${API_BASE_URL}/api/plans/${testFile}`).catch(() => {});
   });
 
   test('should record status_change in audit log', async ({ request }) => {
     // Change the status of the test plan
     const statusResponse = await request.patch(
-      `http://localhost:3001/api/plans/${TEST_PLAN_FILENAME}/status`,
+      `${API_BASE_URL}/api/plans/${TEST_PLAN_FILENAME}/status`,
       {
         data: { status: 'in_progress' },
       }
@@ -214,7 +215,7 @@ test.describe('Quality & Operations functionality (Feature 15)', () => {
 
     // Query audit log for this file
     const auditResponse = await request.get(
-      `http://localhost:3001/api/admin/audit?filename=${TEST_PLAN_FILENAME}`
+      `${API_BASE_URL}/api/admin/audit?filename=${TEST_PLAN_FILENAME}`
     );
     expect(auditResponse.ok()).toBeTruthy();
 
@@ -234,7 +235,7 @@ test.describe('Quality & Operations functionality (Feature 15)', () => {
     // Create a plan without schemaVersion (simulating v0)
     const testFile = 'test-migration-v0.md';
     try {
-      await request.post('http://localhost:3001/api/plans', {
+      await request.post(`${API_BASE_URL}/api/plans`, {
         data: {
           filename: testFile,
           content: `---
@@ -248,7 +249,7 @@ This plan has no schemaVersion.
       });
 
       // Run migration
-      const response = await request.post('http://localhost:3001/api/admin/migrate');
+      const response = await request.post(`${API_BASE_URL}/api/admin/migrate`);
       expect(response.ok()).toBeTruthy();
 
       const result = await response.json();
@@ -256,25 +257,25 @@ This plan has no schemaVersion.
       expect(result.errors).toBeDefined();
 
       // Get the plan and verify it now has schemaVersion
-      const planResponse = await request.get(`http://localhost:3001/api/plans/${testFile}`);
+      const planResponse = await request.get(`${API_BASE_URL}/api/plans/${testFile}`);
       expect(planResponse.ok()).toBeTruthy();
       const plan = await planResponse.json();
       expect(plan.frontmatter.schemaVersion).toBeDefined();
       expect(plan.frontmatter.schemaVersion).toBeGreaterThanOrEqual(1);
     } finally {
-      await request.delete(`http://localhost:3001/api/plans/${testFile}`).catch(() => {});
+      await request.delete(`${API_BASE_URL}/api/plans/${testFile}`).catch(() => {});
     }
   });
 
   test('should skip already-migrated plans', async ({ request }) => {
     // Run migration once
-    const firstResponse = await request.post('http://localhost:3001/api/admin/migrate');
+    const firstResponse = await request.post(`${API_BASE_URL}/api/admin/migrate`);
     expect(firstResponse.ok()).toBeTruthy();
     const firstResult = await firstResponse.json();
     const firstMigrated = firstResult.migrated;
 
     // Run migration again - should migrate 0 since all are already up-to-date
-    const secondResponse = await request.post('http://localhost:3001/api/admin/migrate');
+    const secondResponse = await request.post(`${API_BASE_URL}/api/admin/migrate`);
     expect(secondResponse.ok()).toBeTruthy();
     const secondResult = await secondResponse.json();
 
@@ -284,7 +285,7 @@ This plan has no schemaVersion.
 
   test('should validate audit entry structure', async ({ request }) => {
     // Get recent audit entries
-    const response = await request.get('http://localhost:3001/api/admin/audit?limit=10');
+    const response = await request.get(`${API_BASE_URL}/api/admin/audit?limit=10`);
     expect(response.ok()).toBeTruthy();
 
     const data = await response.json();
@@ -311,7 +312,7 @@ This plan has no schemaVersion.
     try {
       // Create test plans
       for (const filename of bulkFiles) {
-        await request.post('http://localhost:3001/api/plans', {
+        await request.post(`${API_BASE_URL}/api/plans`, {
           data: {
             filename,
             content: `---
@@ -327,7 +328,7 @@ Bulk audit test.
       }
 
       // Perform bulk status change
-      const bulkResponse = await request.post('http://localhost:3001/api/plans/bulk-status', {
+      const bulkResponse = await request.post(`${API_BASE_URL}/api/plans/bulk-status`, {
         data: {
           filenames: bulkFiles,
           status: 'in_progress',
@@ -336,7 +337,7 @@ Bulk audit test.
       expect(bulkResponse.ok()).toBeTruthy();
 
       // Check audit log for entries related to these plans
-      const auditResponse = await request.get('http://localhost:3001/api/admin/audit?limit=20');
+      const auditResponse = await request.get(`${API_BASE_URL}/api/admin/audit?limit=20`);
       expect(auditResponse.ok()).toBeTruthy();
 
       const data = await auditResponse.json();
@@ -347,19 +348,19 @@ Bulk audit test.
       expect(bulkEntries.length).toBeGreaterThan(0);
     } finally {
       for (const filename of bulkFiles) {
-        await request.delete(`http://localhost:3001/api/plans/${filename}`).catch(() => {});
+        await request.delete(`${API_BASE_URL}/api/plans/${filename}`).catch(() => {});
       }
     }
   });
 
   test('API: conflict detection responds with stale mtime info', async ({ request }) => {
     // Use status update to set modified field
-    await request.patch(`http://localhost:3001/api/plans/${TEST_PLAN_FILENAME}/status`, {
+    await request.patch(`${API_BASE_URL}/api/plans/${TEST_PLAN_FILENAME}/status`, {
       data: { status: 'in_progress' },
     });
 
     // Get plan with modified timestamp set
-    const getResponse = await request.get(`http://localhost:3001/api/plans/${TEST_PLAN_FILENAME}`);
+    const getResponse = await request.get(`${API_BASE_URL}/api/plans/${TEST_PLAN_FILENAME}`);
     expect(getResponse.ok()).toBeTruthy();
     const plan = await getResponse.json();
     const originalModified = plan.frontmatter?.modified;
@@ -369,7 +370,7 @@ Bulk audit test.
     await new Promise((resolve) => setTimeout(resolve, 1100));
 
     // Another status update to change modified
-    await request.patch(`http://localhost:3001/api/plans/${TEST_PLAN_FILENAME}/status`, {
+    await request.patch(`${API_BASE_URL}/api/plans/${TEST_PLAN_FILENAME}/status`, {
       data: { status: 'review' },
     });
 
@@ -377,12 +378,12 @@ Bulk audit test.
     await new Promise((resolve) => setTimeout(resolve, 1100));
 
     // One more status update
-    await request.patch(`http://localhost:3001/api/plans/${TEST_PLAN_FILENAME}/status`, {
+    await request.patch(`${API_BASE_URL}/api/plans/${TEST_PLAN_FILENAME}/status`, {
       data: { status: 'completed' },
     });
 
     // Get the final plan to verify mtime tracking works
-    const finalResponse = await request.get(`http://localhost:3001/api/plans/${TEST_PLAN_FILENAME}`);
+    const finalResponse = await request.get(`${API_BASE_URL}/api/plans/${TEST_PLAN_FILENAME}`);
     expect(finalResponse.ok()).toBeTruthy();
     const finalPlan = await finalResponse.json();
 

--- a/e2e/tests/review.spec.ts
+++ b/e2e/tests/review.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { API_BASE_URL } from '../lib/test-helpers';
 
 test.describe.configure({ mode: 'serial' });
 
@@ -27,7 +28,7 @@ Final summary.
 
 test.describe('Review page', () => {
   test.beforeEach(async ({ request, page }) => {
-    await request.post('http://localhost:3001/api/plans', {
+    await request.post(`${API_BASE_URL}/api/plans`, {
       data: {
         filename: TEST_PLAN_FILENAME,
         content: TEST_PLAN_CONTENT,
@@ -41,7 +42,7 @@ test.describe('Review page', () => {
   });
 
   test.afterEach(async ({ request }) => {
-    await request.delete(`http://localhost:3001/api/plans/${TEST_PLAN_FILENAME}`).catch(() => {});
+    await request.delete(`${API_BASE_URL}/api/plans/${TEST_PLAN_FILENAME}`).catch(() => {});
   });
 
   test('should navigate from detail to review page', async ({ page }) => {

--- a/e2e/tests/saved-views.spec.ts
+++ b/e2e/tests/saved-views.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { API_BASE_URL } from '../lib/test-helpers';
 
 // Run tests serially to avoid state conflicts
 test.describe.configure({ mode: 'serial' });
@@ -9,13 +10,13 @@ test.describe('Saved Views (Feature 7)', () => {
   test.afterEach(async ({ request }) => {
     // Clean up: delete created custom view if it exists
     if (createdViewId) {
-      await request.delete(`http://localhost:3001/api/views/${createdViewId}`).catch(() => {});
+      await request.delete(`${API_BASE_URL}/api/views/${createdViewId}`).catch(() => {});
       createdViewId = null;
     }
   });
 
   test('API: should retrieve views list with preset views', async ({ request }) => {
-    const response = await request.get('http://localhost:3001/api/views');
+    const response = await request.get(`${API_BASE_URL}/api/views`);
 
     expect(response.ok()).toBeTruthy();
     const data = await response.json();
@@ -39,7 +40,7 @@ test.describe('Saved Views (Feature 7)', () => {
       sortOrder: 'asc' as const,
     };
 
-    const response = await request.post('http://localhost:3001/api/views', {
+    const response = await request.post(`${API_BASE_URL}/api/views`, {
       data: viewData,
     });
 
@@ -59,7 +60,7 @@ test.describe('Saved Views (Feature 7)', () => {
 
   test('API: should delete a custom view', async ({ request }) => {
     // First create a view
-    const createResponse = await request.post('http://localhost:3001/api/views', {
+    const createResponse = await request.post(`${API_BASE_URL}/api/views`, {
       data: {
         name: 'View to Delete',
         filters: { status: 'todo' },
@@ -71,12 +72,12 @@ test.describe('Saved Views (Feature 7)', () => {
     const viewId = createData.id;
 
     // Delete the view
-    const deleteResponse = await request.delete(`http://localhost:3001/api/views/${viewId}`);
+    const deleteResponse = await request.delete(`${API_BASE_URL}/api/views/${viewId}`);
 
     expect(deleteResponse.ok()).toBeTruthy();
 
     // Verify it no longer exists
-    const listResponse = await request.get('http://localhost:3001/api/views');
+    const listResponse = await request.get(`${API_BASE_URL}/api/views`);
     const listData = await listResponse.json();
 
     const viewExists = listData.views.some((v: any) => v.id === viewId);
@@ -85,7 +86,7 @@ test.describe('Saved Views (Feature 7)', () => {
 
   test('API: should update a custom view', async ({ request }) => {
     // Create a view
-    const createResponse = await request.post('http://localhost:3001/api/views', {
+    const createResponse = await request.post(`${API_BASE_URL}/api/views`, {
       data: {
         name: 'Original Name',
         filters: { status: 'todo' },
@@ -97,7 +98,7 @@ test.describe('Saved Views (Feature 7)', () => {
     createdViewId = createData.id;
 
     // Update the view
-    const updateResponse = await request.put(`http://localhost:3001/api/views/${createdViewId}`, {
+    const updateResponse = await request.put(`${API_BASE_URL}/api/views/${createdViewId}`, {
       data: {
         name: 'Updated Name',
         filters: { status: 'completed' },
@@ -146,7 +147,7 @@ test.describe('Saved Views (Feature 7)', () => {
 
   test('API: should apply view filters correctly', async ({ request }) => {
     // Create a view with status:in_progress filter
-    const createResponse = await request.post('http://localhost:3001/api/views', {
+    const createResponse = await request.post(`${API_BASE_URL}/api/views`, {
       data: {
         name: 'In Progress Filter Test',
         filters: { status: 'in_progress' },
@@ -161,7 +162,7 @@ test.describe('Saved Views (Feature 7)', () => {
     expect(viewData.filters.status).toBe('in_progress');
 
     // List views and find our created view
-    const listResponse = await request.get('http://localhost:3001/api/views');
+    const listResponse = await request.get(`${API_BASE_URL}/api/views`);
     const listData = await listResponse.json();
 
     const view = listData.views.find((v: any) => v.id === createdViewId);
@@ -171,7 +172,7 @@ test.describe('Saved Views (Feature 7)', () => {
 
   test('API: should not allow deleting preset views', async ({ request }) => {
     // Try to delete a preset view
-    const deleteResponse = await request.delete('http://localhost:3001/api/views/preset-in-progress');
+    const deleteResponse = await request.delete(`${API_BASE_URL}/api/views/preset-in-progress`);
 
     // Preset IDs are not UUIDs, so validation should reject them (400)
     // or the service should return 404 since presets are not in custom views
@@ -180,7 +181,7 @@ test.describe('Saved Views (Feature 7)', () => {
   });
 
   test('API: should create view with tags filter', async ({ request }) => {
-    const createResponse = await request.post('http://localhost:3001/api/views', {
+    const createResponse = await request.post(`${API_BASE_URL}/api/views`, {
       data: {
         name: 'API Tag View',
         filters: { tags: ['api'] },
@@ -196,7 +197,7 @@ test.describe('Saved Views (Feature 7)', () => {
   });
 
   test('API: should create view with date range filter', async ({ request }) => {
-    const createResponse = await request.post('http://localhost:3001/api/views', {
+    const createResponse = await request.post(`${API_BASE_URL}/api/views`, {
       data: {
         name: 'Date Range View',
         filters: {
@@ -215,7 +216,7 @@ test.describe('Saved Views (Feature 7)', () => {
   });
 
   test('API: should create view with searchQuery', async ({ request }) => {
-    const createResponse = await request.post('http://localhost:3001/api/views', {
+    const createResponse = await request.post(`${API_BASE_URL}/api/views`, {
       data: {
         name: 'Search Query View',
         filters: {

--- a/e2e/tests/status-filtering.spec.ts
+++ b/e2e/tests/status-filtering.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { API_BASE_URL } from '../lib/test-helpers';
 
 // Fixture files:
 // - blue-running-fox.md (todo)
@@ -145,7 +146,7 @@ test.describe('Status Filtering and Status Update', () => {
     await expect(planCard.getByRole('button', { name: 'Review' })).toBeVisible();
 
     // Reset status back for other tests
-    await request.patch('http://localhost:3001/api/plans/green-dancing-cat.md/status', {
+    await request.patch(`${API_BASE_URL}/api/plans/green-dancing-cat.md/status`, {
       data: { status: 'in_progress' },
     });
   });

--- a/e2e/tests/status-transitions.spec.ts
+++ b/e2e/tests/status-transitions.spec.ts
@@ -1,9 +1,8 @@
 import { test, expect } from '@playwright/test';
+import { API_BASE_URL } from '../lib/test-helpers';
 
 // Run tests serially to avoid state conflicts
 test.describe.configure({ mode: 'serial' });
-
-const API_BASE_URL = 'http://localhost:3001';
 const FIXTURE_FILE = 'blue-running-fox.md'; // Fixture with status=todo
 
 test.describe('Status Transitions (Feature 3)', () => {

--- a/e2e/tests/subtasks.spec.ts
+++ b/e2e/tests/subtasks.spec.ts
@@ -1,9 +1,8 @@
 import { test, expect } from '@playwright/test';
+import { API_BASE_URL } from '../lib/test-helpers';
 
 // Run tests serially to avoid state conflicts
 test.describe.configure({ mode: 'serial' });
-
-const API_BASE_URL = 'http://localhost:3001';
 const FIXTURE_WITH_SUBTASKS = 'green-dancing-cat.md'; // Has 3 subtasks: 1 done, 2 todo
 
 test.describe('Subtasks (Feature 4)', () => {

--- a/e2e/tests/templates.spec.ts
+++ b/e2e/tests/templates.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { API_BASE_URL } from '../lib/test-helpers';
 
 // Run tests serially to avoid state conflicts
 test.describe.configure({ mode: 'serial' });
@@ -8,7 +9,7 @@ const CUSTOM_TEMPLATE_NAME = 'test-custom-template';
 test.describe('Templates functionality (Feature 12)', () => {
   test.afterEach(async ({ request }) => {
     // Clean up: try to delete custom template if created
-    await request.delete(`http://localhost:3001/api/templates/${CUSTOM_TEMPLATE_NAME}`).catch(() => {});
+    await request.delete(`${API_BASE_URL}/api/templates/${CUSTOM_TEMPLATE_NAME}`).catch(() => {});
   });
 
   test('should navigate to /templates page', async ({ page }) => {
@@ -17,7 +18,7 @@ test.describe('Templates functionality (Feature 12)', () => {
   });
 
   test('should include built-in templates in API response', async ({ request }) => {
-    const response = await request.get('http://localhost:3001/api/templates');
+    const response = await request.get(`${API_BASE_URL}/api/templates`);
     expect(response.ok()).toBeTruthy();
 
     const data = await response.json();
@@ -37,7 +38,7 @@ test.describe('Templates functionality (Feature 12)', () => {
   });
 
   test('should retrieve template content via API', async ({ request }) => {
-    const response = await request.get('http://localhost:3001/api/templates/research');
+    const response = await request.get(`${API_BASE_URL}/api/templates/research`);
     expect(response.ok()).toBeTruthy();
 
     const template = await response.json();
@@ -49,7 +50,7 @@ test.describe('Templates functionality (Feature 12)', () => {
   });
 
   test('should create plan from template via API', async ({ request }) => {
-    const response = await request.post('http://localhost:3001/api/templates/from-template', {
+    const response = await request.post(`${API_BASE_URL}/api/templates/from-template`, {
       data: {
         templateName: 'implementation',
         title: 'Test Implementation Plan',
@@ -62,17 +63,17 @@ test.describe('Templates functionality (Feature 12)', () => {
     expect(plan.title).toContain('Test Implementation Plan');
 
     // Verify content via plan detail API
-    const detailResponse = await request.get(`http://localhost:3001/api/plans/${plan.filename}`);
+    const detailResponse = await request.get(`${API_BASE_URL}/api/plans/${plan.filename}`);
     expect(detailResponse.ok()).toBeTruthy();
     const detail = await detailResponse.json();
     expect(detail.content).toContain('Test Implementation Plan');
 
     // Clean up created plan
-    await request.delete(`http://localhost:3001/api/plans/${plan.filename}`).catch(() => {});
+    await request.delete(`${API_BASE_URL}/api/plans/${plan.filename}`).catch(() => {});
   });
 
   test('should create custom template via API', async ({ request }) => {
-    const response = await request.post('http://localhost:3001/api/templates', {
+    const response = await request.post(`${API_BASE_URL}/api/templates`, {
       data: {
         name: CUSTOM_TEMPLATE_NAME,
         displayName: 'Test Custom Template',
@@ -92,13 +93,13 @@ test.describe('Templates functionality (Feature 12)', () => {
     expect(template.isBuiltIn).toBe(false);
 
     // Verify template was created
-    const getResponse = await request.get(`http://localhost:3001/api/templates/${CUSTOM_TEMPLATE_NAME}`);
+    const getResponse = await request.get(`${API_BASE_URL}/api/templates/${CUSTOM_TEMPLATE_NAME}`);
     expect(getResponse.ok()).toBeTruthy();
   });
 
   test('should delete custom template via API', async ({ request }) => {
     // Create custom template first
-    await request.post('http://localhost:3001/api/templates', {
+    await request.post(`${API_BASE_URL}/api/templates`, {
       data: {
         name: CUSTOM_TEMPLATE_NAME,
         displayName: 'Test Custom Template',
@@ -110,17 +111,17 @@ test.describe('Templates functionality (Feature 12)', () => {
 
     // Delete the template
     const deleteResponse = await request.delete(
-      `http://localhost:3001/api/templates/${CUSTOM_TEMPLATE_NAME}`
+      `${API_BASE_URL}/api/templates/${CUSTOM_TEMPLATE_NAME}`
     );
     expect(deleteResponse.ok()).toBeTruthy();
 
     // Verify template is gone
-    const getResponse = await request.get(`http://localhost:3001/api/templates/${CUSTOM_TEMPLATE_NAME}`);
+    const getResponse = await request.get(`${API_BASE_URL}/api/templates/${CUSTOM_TEMPLATE_NAME}`);
     expect(getResponse.status()).toBe(404);
   });
 
   test('should not delete built-in template', async ({ request }) => {
-    const response = await request.delete('http://localhost:3001/api/templates/research');
+    const response = await request.delete(`${API_BASE_URL}/api/templates/research`);
     expect(response.status()).toBe(403);
 
     const error = await response.json();
@@ -161,7 +162,7 @@ test.describe('Templates functionality (Feature 12)', () => {
     // The templates page shows cards - check if there's a "Use Template" or similar action
     // Since the current TemplatesPage may not have a "Use Template" button,
     // we'll verify the API-based template creation works correctly
-    const response = await request.post('http://localhost:3001/api/templates/from-template', {
+    const response = await request.post(`${API_BASE_URL}/api/templates/from-template`, {
       data: {
         templateName: 'research',
         title: 'UI Created Research Plan',
@@ -174,12 +175,12 @@ test.describe('Templates functionality (Feature 12)', () => {
     expect(plan.title).toContain('UI Created Research Plan');
 
     // Clean up
-    await request.delete(`http://localhost:3001/api/plans/${plan.filename}`).catch(() => {});
+    await request.delete(`${API_BASE_URL}/api/plans/${plan.filename}`).catch(() => {});
   });
 
   test('should apply template frontmatter defaults to created plan', async ({ request }) => {
     // Create plan from incident template which should have status=in_progress, priority=critical
-    const response = await request.post('http://localhost:3001/api/templates/from-template', {
+    const response = await request.post(`${API_BASE_URL}/api/templates/from-template`, {
       data: {
         templateName: 'incident',
         title: 'Test Incident Response',
@@ -191,7 +192,7 @@ test.describe('Templates functionality (Feature 12)', () => {
     expect(plan.filename).toBeDefined();
 
     // Get the created plan to check frontmatter
-    const planResponse = await request.get(`http://localhost:3001/api/plans/${plan.filename}`);
+    const planResponse = await request.get(`${API_BASE_URL}/api/plans/${plan.filename}`);
     expect(planResponse.ok()).toBeTruthy();
     const planDetail = await planResponse.json();
 
@@ -201,12 +202,12 @@ test.describe('Templates functionality (Feature 12)', () => {
     expect(planDetail.frontmatter.priority).toBeDefined();
 
     // Clean up
-    await request.delete(`http://localhost:3001/api/plans/${plan.filename}`).catch(() => {});
+    await request.delete(`${API_BASE_URL}/api/plans/${plan.filename}`).catch(() => {});
   });
 
   test('should substitute {{title}} placeholder in template content', async ({ request }) => {
     const title = 'My Custom Research Title';
-    const response = await request.post('http://localhost:3001/api/templates/from-template', {
+    const response = await request.post(`${API_BASE_URL}/api/templates/from-template`, {
       data: {
         templateName: 'research',
         title,
@@ -218,7 +219,7 @@ test.describe('Templates functionality (Feature 12)', () => {
     expect(plan.filename).toBeDefined();
 
     // Get plan detail to check content
-    const detailResponse = await request.get(`http://localhost:3001/api/plans/${plan.filename}`);
+    const detailResponse = await request.get(`${API_BASE_URL}/api/plans/${plan.filename}`);
     expect(detailResponse.ok()).toBeTruthy();
     const detail = await detailResponse.json();
 
@@ -228,11 +229,11 @@ test.describe('Templates functionality (Feature 12)', () => {
     expect(detail.content).not.toContain('{{title}}');
 
     // Clean up
-    await request.delete(`http://localhost:3001/api/plans/${plan.filename}`).catch(() => {});
+    await request.delete(`${API_BASE_URL}/api/plans/${plan.filename}`).catch(() => {});
   });
 
   test('should show template category in API response', async ({ request }) => {
-    const response = await request.get('http://localhost:3001/api/templates');
+    const response = await request.get(`${API_BASE_URL}/api/templates`);
     expect(response.ok()).toBeTruthy();
 
     const data = await response.json();
@@ -256,7 +257,7 @@ test.describe('Templates functionality (Feature 12)', () => {
 
     try {
       // Create custom template with frontmatter defaults
-      const createResponse = await request.post('http://localhost:3001/api/templates', {
+      const createResponse = await request.post(`${API_BASE_URL}/api/templates`, {
         data: {
           name: customName,
           displayName: 'Test Frontmatter Template',
@@ -273,7 +274,7 @@ test.describe('Templates functionality (Feature 12)', () => {
       expect(createResponse.status()).toBe(201);
 
       // Create a plan from this template
-      const planResponse = await request.post('http://localhost:3001/api/templates/from-template', {
+      const planResponse = await request.post(`${API_BASE_URL}/api/templates/from-template`, {
         data: {
           templateName: customName,
           title: 'Plan From Custom Template',
@@ -284,17 +285,17 @@ test.describe('Templates functionality (Feature 12)', () => {
       const plan = await planResponse.json();
 
       // Get full plan details to verify frontmatter
-      const detailResponse = await request.get(`http://localhost:3001/api/plans/${plan.filename}`);
+      const detailResponse = await request.get(`${API_BASE_URL}/api/plans/${plan.filename}`);
       expect(detailResponse.ok()).toBeTruthy();
       const detail = await detailResponse.json();
 
       expect(detail.frontmatter).toBeDefined();
 
       // Clean up created plan
-      await request.delete(`http://localhost:3001/api/plans/${plan.filename}`).catch(() => {});
+      await request.delete(`${API_BASE_URL}/api/plans/${plan.filename}`).catch(() => {});
     } finally {
       // Clean up template
-      await request.delete(`http://localhost:3001/api/templates/${customName}`).catch(() => {});
+      await request.delete(`${API_BASE_URL}/api/templates/${customName}`).catch(() => {});
     }
   });
 });

--- a/e2e/tests/validation.spec.ts
+++ b/e2e/tests/validation.spec.ts
@@ -1,9 +1,8 @@
 import { test, expect } from '@playwright/test';
+import { API_BASE_URL } from '../lib/test-helpers';
 
 // Run tests serially to avoid state conflicts
 test.describe.configure({ mode: 'serial' });
-
-const API_BASE_URL = 'http://localhost:3001';
 
 test.describe('Validation (Feature 2)', () => {
   test('should handle plan creation with invalid frontmatter gracefully', async ({ request }) => {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "@types/node": "^20.11.0",
     "prettier": "^3.2.0",
+    "tsx": "^4.7.0",
     "typescript": "^5.3.0"
   },
   "packageManager": "pnpm@9.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       prettier:
         specifier: ^3.2.0
         version: 3.8.1
+      tsx:
+        specifier: ^4.7.0
+        version: 4.21.0
       typescript:
         specifier: ^5.3.0
         version: 5.9.3


### PR DESCRIPTION
## Summary

- Derive unique API/WEB ports from worktree path MD5 hash (range 10000-60000) so multiple worktrees can run `pnpm test:e2e` simultaneously without port conflicts
- Dev server defaults (3001/5173) are always avoided, enabling `pnpm dev` and `pnpm test:e2e` to coexist
- Support `API_PORT`/`WEB_PORT` env var overrides for manual control
- Refactor all 18 E2E test files to use shared `API_BASE_URL` import instead of hardcoded `localhost:3001`

### Files changed (26 files, +384 -230)

| Category | Files |
|----------|-------|
| New: Port utility | `e2e/lib/ports.ts`, `e2e/lib/test-helpers.ts`, `e2e/lib/__tests__/ports.test.ts` |
| Config updates | `e2e/playwright.config.ts`, `apps/web/vite.config.ts`, `apps/api/src/config.ts` |
| E2E test refactor | 18 spec files (replaced hardcoded URLs with dynamic `API_BASE_URL`) |
| Dependencies | `package.json`, `pnpm-lock.yaml` (added `tsx` for unit tests) |

## Test plan

- [x] Unit tests for port derivation: 10/10 passing
- [x] E2E tests: 231/232 passing, 1 skipped, 0 failures
- [x] Build: passes (API + Web)
- [x] Type check: passes
- [x] grep verification: 0 remaining `localhost:3001` or `localhost:5173` in `e2e/`
- [ ] Manual: Run `pnpm dev` + `pnpm test:e2e` simultaneously (no conflict)
- [ ] Manual: Run `pnpm test:e2e` from 2 worktrees simultaneously (no conflict)

🤖 Generated with [Claude Code](https://claude.com/claude-code)