### PR TITLE
fix: Handle unknown frontmatter status values in StatusBadge

### DIFF
--- a/apps/web/src/components/plan/StatusBadge.tsx
+++ b/apps/web/src/components/plan/StatusBadge.tsx
@@ -29,7 +29,10 @@ const statusConfig: Record<PlanStatus, { label: string; className: string }> = {
 export function StatusBadge({ status, onClick, interactive = false }: StatusBadgeProps) {
   if (!status) return null;
 
-  const config = statusConfig[status];
+  const config = statusConfig[status] ?? {
+    label: status,
+    className: 'bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-300',
+  };
   const baseClassName = cn(
     'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium',
     config.className,


### PR DESCRIPTION
## Summary

- StatusBadge crashed with `Cannot read properties of undefined (reading 'className')` when a plan had a YAML frontmatter status not in the predefined config map (e.g. `"draft"`)
- Since users can write arbitrary values in YAML frontmatter, added a gray fallback style for unrecognized statuses instead of crashing
- Unknown statuses now display as gray badges with the raw status string as the label

## Test plan

- [ ] Open the app and verify plans with known statuses (todo, in_progress, review, completed) render correctly
- [ ] Verify plans with unknown statuses (e.g. "draft") render with gray badge
- [ ] Verify no console errors on page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Status badges now display correctly for all status types, including previously unhandled ones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->