### PR TITLE
fix: limit outline scroll offset in detail view

### DIFF
--- a/apps/electron/src/renderer/__tests__/components/plan/SectionNav.test.tsx
+++ b/apps/electron/src/renderer/__tests__/components/plan/SectionNav.test.tsx
@@ -57,6 +57,10 @@ describe('SectionNav', () => {
     );
 
     fireEvent.click(screen.getByRole('button', { name: '日本語の見出し' }));
-    expect(scrollIntoViewMock).toHaveBeenCalledWith({ behavior: 'smooth', block: 'start' });
+    expect(scrollIntoViewMock).toHaveBeenCalledWith({
+      behavior: 'smooth',
+      block: 'nearest',
+      inline: 'nearest',
+    });
   });
 });

--- a/apps/electron/src/renderer/components/plan/SectionNav.tsx
+++ b/apps/electron/src/renderer/components/plan/SectionNav.tsx
@@ -86,7 +86,7 @@ export function SectionNav({ content }: SectionNavProps) {
   const scrollToHeading = (index: number) => {
     const el = getRenderedHeadingElements()[index];
     if (el) {
-      el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      el.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'nearest' });
     }
   };
 


### PR DESCRIPTION
## Summary
- change outline jump behavior in detail view from top-align to nearest-align
- prevent overscrolling so the selected section remains visible after click
- update SectionNav unit test expectation for new scroll behavior

## Testing
- pnpm --filter @ccplans/electron test -- SectionNav.test.tsx
- pre-commit hooks ran lint and full test suite on commit (passed)

Closes #38

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scroll behavior when navigating between sections with smoother alignment handling.

* **Tests**
  * Updated test assertions to reflect improved scroll behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->