### PR TITLE
fix: autofocus command palette input on open

### DIFF
--- a/apps/electron/src/renderer/__tests__/components/workbench/CommandPalette.test.tsx
+++ b/apps/electron/src/renderer/__tests__/components/workbench/CommandPalette.test.tsx
@@ -1,0 +1,36 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { CommandPalette } from '@/components/workbench/CommandPalette';
+
+const items = [
+  {
+    id: 'test-command',
+    label: 'Test Command',
+    run: vi.fn(),
+  },
+];
+
+describe('CommandPalette', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('focuses the command input when opened', async () => {
+    render(<CommandPalette open items={items} onClose={vi.fn()} />);
+
+    const input = screen.getByPlaceholderText('Type a command...');
+    await waitFor(() => {
+      expect(input).toBe(document.activeElement);
+    });
+  });
+
+  it('focuses input when open changes from false to true', async () => {
+    const { rerender } = render(<CommandPalette open={false} items={items} onClose={vi.fn()} />);
+    rerender(<CommandPalette open items={items} onClose={vi.fn()} />);
+
+    const input = screen.getByPlaceholderText('Type a command...');
+    await waitFor(() => {
+      expect(input).toBe(document.activeElement);
+    });
+  });
+});

--- a/apps/electron/src/renderer/components/workbench/CommandPalette.tsx
+++ b/apps/electron/src/renderer/components/workbench/CommandPalette.tsx
@@ -1,5 +1,5 @@
 import { Command, CornerDownLeft, Search } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { cn } from '@/lib/utils';
 
 export interface CommandItem {
@@ -26,6 +26,7 @@ export function CommandPalette({
 }: CommandPaletteProps) {
   const [query, setQuery] = useState('');
   const [activeIndex, setActiveIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const filteredItems = useMemo(() => {
     const normalized = query.trim().toLowerCase();
@@ -75,6 +76,11 @@ export function CommandPalette({
     setActiveIndex(0);
   }, [filteredItems.length]);
 
+  useEffect(() => {
+    if (!open) return;
+    inputRef.current?.focus();
+  }, [open]);
+
   if (!open) return null;
 
   return (
@@ -92,6 +98,7 @@ export function CommandPalette({
         <div className="relative border-b border-slate-700">
           <Search className="pointer-events-none absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-slate-400" />
           <input
+            ref={inputRef}
             value={query}
             onChange={(event) => setQuery(event.target.value)}
             placeholder={placeholder}


### PR DESCRIPTION
## Summary
- focus the command palette input automatically when the palette opens
- ensure Cmd+K users can type immediately without extra click
- add tests for both initial open and closed-to-open transition

## Testing
- pnpm --filter @ccplans/electron test -- CommandPalette.test.tsx
- pnpm --filter @ccplans/electron lint
- pre-commit hooks: full lint + full test suite passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Command palette input now automatically receives focus when opened, streamlining command entry.

* **Tests**
  * Added unit tests validating the command palette correctly focuses the input field when opened and when toggled via component updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->