### PR TITLE
chore: standardize agent-plans default directory and Claude legacy fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,14 +70,14 @@ hooks/          # Hook scripts
 
 | Variable | Default | Description |
 | --- | --- | --- |
-| `PLANS_DIR` | `~/.claude/plans` | Plan file directory (set to `~/.codex/plans` for Codex workflows) |
+| `PLANS_DIR` | `~/.agent-plans/plans` | Plan file directory (`~/.claude/plans` is auto-detected as legacy fallback) |
 | `ARCHIVE_DIR` | `<PLANS_DIR>/archive` | Archive directory (legacy/internal) |
 | `ARCHIVE_RETENTION_DAYS` | `30` | Archive retention days (legacy/internal) |
 | `OPEN_DEVTOOLS` | `false` | Open devtools in Electron dev mode |
 
 ## Hook
 
-This repository includes a plan-metadata hook script for Claude Code:
+This repository includes a plan-metadata hook script for agent workflows (Claude Code supported):
 
 - `hooks/plan-metadata/inject.py`
 - See `hooks/plan-metadata/README.md` for setup.

--- a/apps/electron/src/main/__tests__/services/config.test.ts
+++ b/apps/electron/src/main/__tests__/services/config.test.ts
@@ -5,8 +5,10 @@ describe('config', () => {
   describe('default values', () => {
     it('should have plansDir defined', () => {
       expect(config.plansDir).toBeDefined();
-      expect(config.plansDir).toContain('.claude');
       expect(config.plansDir).toContain('plans');
+      expect(config.plansDir.includes('.agent-plans') || config.plansDir.includes('.claude')).toBe(
+        true
+      );
     });
 
     it('should have archiveDir defined', () => {

--- a/apps/electron/src/main/config.ts
+++ b/apps/electron/src/main/config.ts
@@ -1,7 +1,27 @@
+import { existsSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
-const plansDir = process.env.PLANS_DIR || join(homedir(), '.claude', 'plans');
+const AGENT_PLANS_DIR = join(homedir(), '.agent-plans', 'plans');
+const LEGACY_CLAUDE_PLANS_DIR = join(homedir(), '.claude', 'plans');
+
+function resolvePlansDir(): string {
+  if (process.env.PLANS_DIR) {
+    return process.env.PLANS_DIR;
+  }
+
+  if (existsSync(AGENT_PLANS_DIR)) {
+    return AGENT_PLANS_DIR;
+  }
+
+  if (existsSync(LEGACY_CLAUDE_PLANS_DIR)) {
+    return LEGACY_CLAUDE_PLANS_DIR;
+  }
+
+  return AGENT_PLANS_DIR;
+}
+
+const plansDir = resolvePlansDir();
 
 export const config = {
   /** Directory containing plan files */

--- a/apps/electron/src/main/services/__tests__/openerService.test.ts
+++ b/apps/electron/src/main/services/__tests__/openerService.test.ts
@@ -39,13 +39,13 @@ describe('OpenerService', () => {
   it('opens Terminal at the file directory on macOS', async () => {
     const { OpenerService } = await import('../openerService.js');
     const service = new OpenerService();
-    const filePath = '/Users/test/.claude/plans/sample.md';
+    const filePath = '/Users/test/.agent-plans/plans/sample.md';
 
     await service.openFile(filePath, 'terminal');
 
     expect(spawnMock).toHaveBeenCalledWith(
       'open',
-      ['-a', 'Terminal', '/Users/test/.claude/plans'],
+      ['-a', 'Terminal', '/Users/test/.agent-plans/plans'],
       expect.objectContaining({
         detached: true,
         stdio: 'ignore',
@@ -56,13 +56,13 @@ describe('OpenerService', () => {
   it('opens Ghostty by opening the file directory on macOS', async () => {
     const { OpenerService } = await import('../openerService.js');
     const service = new OpenerService();
-    const filePath = '/Users/test/.claude/plans/sample.md';
+    const filePath = '/Users/test/.agent-plans/plans/sample.md';
 
     await service.openFile(filePath, 'ghostty');
 
     expect(spawnMock).toHaveBeenCalledWith(
       'open',
-      ['-a', 'Ghostty', '/Users/test/.claude/plans'],
+      ['-a', 'Ghostty', '/Users/test/.agent-plans/plans'],
       expect.objectContaining({
         detached: true,
         stdio: 'ignore',
@@ -73,7 +73,7 @@ describe('OpenerService', () => {
   it('copies full file path for copy-path action', async () => {
     const { OpenerService } = await import('../openerService.js');
     const service = new OpenerService();
-    const filePath = '/Users/test/.claude/plans/sample.md';
+    const filePath = '/Users/test/.agent-plans/plans/sample.md';
 
     await service.openFile(filePath, 'copy-path');
 
@@ -85,7 +85,7 @@ describe('OpenerService', () => {
     platformMock.mockReturnValue('linux');
     const { OpenerService } = await import('../openerService.js');
     const service = new OpenerService();
-    const filePath = '/Users/test/.claude/plans/sample.md';
+    const filePath = '/Users/test/.agent-plans/plans/sample.md';
 
     await service.openFile(filePath, 'zed');
 

--- a/apps/electron/src/renderer/lib/api/__tests__/ipcClient.test.ts
+++ b/apps/electron/src/renderer/lib/api/__tests__/ipcClient.test.ts
@@ -177,7 +177,7 @@ describe('ipcClient', () => {
       const { ipcClient } = await import('../ipcClient');
       mockInvoke.mockResolvedValueOnce({
         frontmatterEnabled: true,
-        planDirectories: ['~/.claude/plans'],
+        planDirectories: ['~/.agent-plans/plans'],
         shortcuts: DEFAULT_SHORTCUTS,
       });
 
@@ -190,19 +190,19 @@ describe('ipcClient', () => {
       const { ipcClient } = await import('../ipcClient');
       mockInvoke.mockResolvedValueOnce({
         frontmatterEnabled: false,
-        planDirectories: ['~/.claude/plans'],
+        planDirectories: ['~/.agent-plans/plans'],
         shortcuts: DEFAULT_SHORTCUTS,
       });
 
       await ipcClient.settings.update({
         frontmatterEnabled: true,
-        planDirectories: ['~/.claude/plans'],
+        planDirectories: ['~/.agent-plans/plans'],
         shortcuts: DEFAULT_SHORTCUTS,
       });
 
       expect(mockInvoke).toHaveBeenCalledWith('settings:update', {
         frontmatterEnabled: true,
-        planDirectories: ['~/.claude/plans'],
+        planDirectories: ['~/.agent-plans/plans'],
         shortcuts: DEFAULT_SHORTCUTS,
       });
     });

--- a/apps/electron/src/renderer/pages/SettingsPage.tsx
+++ b/apps/electron/src/renderer/pages/SettingsPage.tsx
@@ -33,7 +33,7 @@ const FRONTMATTER_FEATURES = [
   { icon: Clock, label: 'Due date tracking with deadline alerts' },
 ];
 
-const DEFAULT_PLAN_DIRECTORY = '~/.claude/plans';
+const DEFAULT_PLAN_DIRECTORY = '~/.agent-plans/plans';
 
 interface DirectoryEntry {
   id: string;
@@ -374,7 +374,7 @@ export function SettingsPage() {
                   type="text"
                   value={entry.path}
                   onChange={(event) => handleDirectoryChange(entry.id, event.target.value)}
-                  placeholder={index === 0 ? '~/.claude/plans' : '/path/to/another/plans'}
+                  placeholder={index === 0 ? '~/.agent-plans/plans' : '/path/to/another/plans'}
                   className="h-10 w-full rounded border border-border bg-background pl-9 pr-3 text-sm outline-none transition focus:border-primary"
                 />
               </div>

--- a/apps/electron/src/renderer/pages/__tests__/SettingsPage.test.tsx
+++ b/apps/electron/src/renderer/pages/__tests__/SettingsPage.test.tsx
@@ -8,7 +8,7 @@ vi.mock('@/lib/hooks/useSettings', () => ({
   useSettings: () => ({
     data: {
       frontmatterEnabled: false,
-      planDirectories: ['~/.claude/plans'],
+      planDirectories: ['~/.agent-plans/plans'],
       shortcuts: DEFAULT_SHORTCUTS,
     },
     isLoading: false,

--- a/codemaps/architecture.md
+++ b/codemaps/architecture.md
@@ -18,7 +18,7 @@ agent-plans/
 ## Data Flow
 
 ```text
-~/.claude/plans/*.md
+~/.agent-plans/plans/*.md (legacy: ~/.claude/plans/*.md)
    ↑            ↓
 main/services (file I/O, parsing, status transitions)
    ↑            ↓

--- a/docs/specifications.md
+++ b/docs/specifications.md
@@ -12,7 +12,7 @@ This spec defines the current Electron-only product baseline.
 
 ## Source of Truth
 
-- Plan files in `PLANS_DIR` (default: `~/.claude/plans`)
+- Plan files in `PLANS_DIR` (default: `~/.agent-plans/plans`, legacy fallback: `~/.claude/plans`)
 - YAML frontmatter is enabled by default in Electron settings
 
 ## Behavioral Requirements

--- a/hooks/plan-metadata/settings.example.json
+++ b/hooks/plan-metadata/settings.example.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ~/.claude/hooks/plan-metadata-inject.py"
+            "command": "python3 ~/.agent-plans/hooks/plan-metadata-inject.py"
           }
         ]
       }

--- a/packages/shared/src/types/plan.ts
+++ b/packages/shared/src/types/plan.ts
@@ -73,7 +73,7 @@ export interface PlanFrontmatter {
   modified?: string;
   /** Project path where plan was created */
   projectPath?: string;
-  /** Claude Code session ID */
+  /** Agent session ID (e.g. Claude Code/Codex) */
   sessionId?: string;
   /** Plan status */
   status?: PlanStatus;


### PR DESCRIPTION
retry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added legacy fallback detection that automatically recognizes the previous plan directory location if the new one isn't present.

* **Documentation**
  * Updated default plan directory path to ~/.agent-plans/plans.
  * Updated plan-metadata hook documentation to reflect broader agent workflow support.

* **Chores**
  * Updated configuration paths and UI references throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->