### PR TITLE
feat: auto-sync Homebrew cask after release

### DIFF
--- a/.github/workflows/homebrew-cask-sync.yml
+++ b/.github/workflows/homebrew-cask-sync.yml
@@ -1,0 +1,115 @@
+name: Sync Homebrew Cask
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to sync (e.g. v0.2.2)
+        required: true
+        type: string
+
+jobs:
+  sync:
+    if: github.event_name != 'release' || github.event.release.prerelease == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      TAP_REPO: tanabe1478/homebrew-agent-plans
+
+    steps:
+      - name: Resolve release tag
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            tag="${{ github.event.release.tag_name }}"
+          else
+            tag="${{ github.event.inputs.tag }}"
+          fi
+
+          if [ -z "$tag" ]; then
+            echo "::error::Release tag is empty"
+            exit 1
+          fi
+
+          echo "TAG=$tag" >> "$GITHUB_ENV"
+          echo "VERSION=${tag#v}" >> "$GITHUB_ENV"
+          echo "Resolved tag: $tag"
+
+      - name: Verify required secrets
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          if [ -z "$HOMEBREW_TAP_TOKEN" ]; then
+            echo "::error::HOMEBREW_TAP_TOKEN is not set"
+            exit 1
+          fi
+
+      - name: Fetch release metadata
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api "repos/${{ github.repository }}/releases/tags/$TAG" > release.json
+
+          asset_url="$(jq -r '.assets[] | select(.name | endswith("-mac-arm64.dmg")) | .browser_download_url' release.json | head -n 1)"
+          asset_name="$(jq -r '.assets[] | select(.name | endswith("-mac-arm64.dmg")) | .name' release.json | head -n 1)"
+
+          if [ -z "$asset_url" ] || [ "$asset_url" = "null" ]; then
+            echo "::error::No macOS arm64 DMG asset found for $TAG"
+            exit 1
+          fi
+
+          echo "ASSET_URL=$asset_url" >> "$GITHUB_ENV"
+          echo "ASSET_NAME=$asset_name" >> "$GITHUB_ENV"
+          echo "Release asset: $asset_name"
+
+      - name: Download asset and calculate sha256
+        run: |
+          curl -fL "$ASSET_URL" -o release.dmg
+          checksum="$(sha256sum release.dmg | awk '{print $1}')"
+
+          if [ -z "$checksum" ]; then
+            echo "::error::Failed to compute SHA256"
+            exit 1
+          fi
+
+          echo "SHA256=$checksum" >> "$GITHUB_ENV"
+          echo "SHA256: $checksum"
+
+      - name: Update cask in tap repository
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          git clone "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/${TAP_REPO}.git" tap
+          cd tap
+
+          if [ ! -f Casks/agent-plans.rb ]; then
+            echo "::error::Casks/agent-plans.rb not found in tap repository"
+            exit 1
+          fi
+
+          VERSION="$VERSION" SHA256="$SHA256" perl -0pi -e 's/version\s+"[^"]+"/version "$ENV{VERSION}"/; s/sha256\s+"[^"]+"/sha256 "$ENV{SHA256}"/;' Casks/agent-plans.rb
+
+          if git diff --quiet -- Casks/agent-plans.rb; then
+            echo "No changes in cask formula. Skipping commit."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add Casks/agent-plans.rb
+          git commit -m "chore: update agent-plans cask to ${VERSION}"
+          git push origin main
+
+      - name: Summary
+        run: |
+          {
+            echo "## Homebrew Cask Sync"
+            echo "- Tag: \\`$TAG\\`"
+            echo "- Asset: \\`$ASSET_NAME\\`"
+            echo "- SHA256: \\`$SHA256\\`"
+            echo "- Tap: \\`$TAP_REPO\\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Release is tag-based and fully automated by GitHub Actions:
 1. Push a `vX.Y.Z` tag (example: `v0.2.1`)
 2. `Release` workflow builds macOS arm64 `.dmg` in `unsigned` (default) or `signed` mode
 3. Artifact is attached to a GitHub Release page
+4. `Sync Homebrew Cask` workflow updates the tap cask (`tanabe1478/homebrew-agent-plans`)
 
 Detailed runbook: `docs/release.md`
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -63,6 +63,20 @@ You can run the workflow manually and choose release mode:
 7. Generate release notes with distribution mode + SHA256 checksums
 8. Upload `apps/electron/release/*.dmg` to GitHub Release
 
+## Automatic Homebrew Cask sync
+
+After a release is published, `Sync Homebrew Cask` workflow updates:
+
+- `tanabe1478/homebrew-agent-plans`
+- `Casks/agent-plans.rb` (`version` and `sha256`)
+
+Required repository secret (`agent-plans` repo):
+
+- `HOMEBREW_TAP_TOKEN`:
+  - Personal Access Token with push access to `tanabe1478/homebrew-agent-plans`
+
+Manual retry is available via `workflow_dispatch` with `tag` input.
+
 ## Local DMG build
 
 Unsigned:


### PR DESCRIPTION
Summary:
- add Sync Homebrew Cask workflow triggered by release published and manual dispatch
- fetch release DMG, compute SHA256, and update tanabe1478/homebrew-agent-plans cask automatically
- document required HOMEBREW_TAP_TOKEN secret and retry flow in release runbook

Validation:
- pnpm check
- pnpm lint
- pnpm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled automatic Homebrew Cask synchronization for new releases.

* **Documentation**
  * Updated release workflow documentation to describe the automatic Homebrew Cask sync process and required configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->