### PR TITLE
fix: resolve Milkdown editorView context error on StrictMode double-mount

### DIFF
--- a/apps/electron/src/renderer/index.css
+++ b/apps/electron/src/renderer/index.css
@@ -531,6 +531,12 @@
   padding: 2px 0;
 }
 
+/* CodeMirror active-line gutter: override default dark/light theme
+   colors that don't match our app theme system. */
+.milkdown-editor-container .milkdown .cm-activeLineGutter {
+  background-color: hsl(var(--accent));
+}
+
 /* Prevent ProseMirror scroll jump on focus/selection change */
 .milkdown-editor-container .ProseMirror .ProseMirror-gapcursor {
   display: none;


### PR DESCRIPTION
## Summary

- Fix "Context 'editorView' not found" error displayed at top of plan detail page by deferring Milkdown Crepe instantiation to `requestAnimationFrame`
- This ensures React StrictMode's synchronous mount → unmount → remount cycle completes before the editor is created, preventing two Crepe instances from competing over the same container
- Fix CodeMirror active-line gutter color mismatch (dark background appearing in light mode) with CSS override

## Root Cause

React StrictMode double-mounts components in development. Two Crepe instances were created for the same container div. During the first instance's destruction, its serializer attempted to access the already-removed `editorViewCtx` context, throwing a `MilkdownError` caught by the global `window.error` handler and displayed in `#boot-fallback`.

## Test plan

- [x] `pnpm lint` — passes
- [x] `pnpm test` — 318 tests pass
- [x] `pnpm build` — builds successfully
- [x] Manual verification: navigate to plan detail → no error banner
- [x] Manual verification: navigate away and back → no error, editor renders correctly
- [ ] E2E tests (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced editor initialization process to prevent concurrent instance creation and ensure proper resource cleanup, lifecycle management, and state synchronization.

* **Style**
  * Updated the active line indicator styling in the code editor to align with the app's accent color for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->