### PR TITLE
fix: disable Milkdown BlockEdit floating handles

### DIFF
--- a/apps/electron/src/renderer/components/plan/MilkdownEditor.tsx
+++ b/apps/electron/src/renderer/components/plan/MilkdownEditor.tsx
@@ -38,6 +38,7 @@ export function MilkdownEditor({
         features: {
           [CrepeFeature.Latex]: false,
           [CrepeFeature.ImageBlock]: false,
+          [CrepeFeature.BlockEdit]: false,
         },
       });
 


### PR DESCRIPTION
## Summary

- Disable Milkdown Crepe's BlockEdit feature (floating "+" button and drag handle that appears on hover)
- These controls are unnecessary for our lightweight editing use case

## Test plan

- [x] `pnpm lint` — passes
- [x] `pnpm test` — 318 tests pass
- [x] `pnpm build` — builds successfully
- [ ] CI / E2E (automated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added configuration option to the editor component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->